### PR TITLE
rock 2a: add eeprom support on i2c1-m0

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -126,7 +126,8 @@ dtb-$(CONFIG_CLK_RK3528) += \
 	rk3528-uart2-m1.dtbo \
 	rk3528-uart3-m0.dtbo \
 	rk3528-uart3-m1.dtbo \
-	rk3528-uart7-m0.dtbo
+	rk3528-uart7-m0.dtbo \
+	rock-2a-eeprom.dtbo
 
 dtb-$(CONFIG_CLK_RK3568) += \
 	audioinjector-isolated-soundcard.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-2a-eeprom.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-2a-eeprom.dts
@@ -1,0 +1,25 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable EEPROM on I2C1-M0";
+		compatible = "radxa,rock-2a";
+		category = "misc";
+		exclusive = "GPIO4_A2", "GPIO4_A3", "i2c1";
+		description = "Enable EEPROM on I2C1-M0.\nThis is a onboard device that we disable by default, so GPIO pins can function as expected.";
+	};
+};
+
+&i2c1 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1m0_xfer>;
+    
+	eeprom:	bl24c16@50 {
+		status = "okay";
+		compatible = "atmel,24c16";
+		reg = <0x50>;
+		pagesize = <16>;
+	};
+};


### PR DESCRIPTION
rock 2a: add eeprom support on i2c1-m0

Signed-off-by: SongJun Li <lisongjun@radxa.com>