### PR TITLE
fix: rk3588-spi0-m1-cs0-mcp2515-8mhz.dts

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-spi0-m1-cs0-mcp2515-8mhz.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-spi0-m1-cs0-mcp2515-8mhz.dts
@@ -9,10 +9,13 @@
 	metadata {
 		title = "Enable MCP2515 with 8MHz external clock on SPI0-M1 over CS0";
 		compatible = "radxa,rock-5a", "radxa,rock-5c", "radxa,cm5-io";
-		exclusive = "GPIO4_A2", "GPIO4_A1", "GPIO4_A0", "GPIO4_B2";
-		description = "Provide support for Microchip MCP2515 SPI CAN controller.
-Assumes 8MHz external clock.
-Uses Pin 31 (GPIOI0_C7) for INT.";
+		exclusive = "GPIO4_A2", "GPIO4_A1", "GPIO4_A0", "GPIO4_B2", "GPIO0_C7";
+		description = "Enable MCP2515 with 8MHz external clock on SPI0-M1 over CS0.
+MCP2515 is a SPI CAN controller from Microchip.
+On Radxa CM5 IO, the interrupt pin is pin 31.
+On Radxa ROCK 5A, the interrupt pin is pin 27.
+On Radxa ROCK 5C, the interrupt pin is pin 27.
+";
 	};
 };
 


### PR DESCRIPTION
Modified the description of the INT pin because rock-5a ,rock-5c and cm5 use different INT pins. rock-5a and rock-5c : pin27
cm5-io: pin31