### PR TITLE
Add Zero 3 USB Host Mode

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-zero3-usb-host.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-zero3-usb-host.dts
@@ -1,0 +1,18 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Set OTG port to Host mode";
+		compatible = "radxa,zero3";
+		category = "misc";
+		exclusive = "usbdrd_dwc3-dr_mode";
+		description = "Set OTG port to Host mode.\nUse this when you want to connect USB devices.";
+	};
+};
+
+&usbdrd_dwc3 {
+	status = "okay";
+	dr_mode = "host";
+	usb-mode-switch;
+};


### PR DESCRIPTION
This dts enables the OTG port on the Zero 3 to be used in USB host mode.
It was based on rk3568-dwc3-host.dts and rk3588-dwc3-otg.dts.
Tested working on a Zero 3W with a variety of "USB OTG adapters" and passthrough hubs.