### PR TITLE
fix: can overlays aren't compiled when kernel is bsp 6.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
             do
               OVERLAY_NAME="$(basename "$i")"
               OVERLAY_NAME="${OVERLAY_NAME/.dts}.dtbo"
-              if ! grep "$OVERLAY_NAME" "${OVERLAY_PATH}/Makefile" >/dev/null 2>/dev/null
+              if ! grep "$OVERLAY_NAME" "${OVERLAY_PATH}/Makefile"* >/dev/null 2>/dev/null
               then
                 echo "$OVERLAY_NAME is not included in $VENDOR Makefile!"
                 MISSING=1

--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -18,6 +18,8 @@ ifeq ($(strip $(CONFIG_CPU_RK3588)), y)
 	CONFIG_CLK_RK3588 ?= y
 endif
 
+-include $(src)/Makefile.rk3588-can
+
 dtb-$(CONFIG_CLK_RK3308) += \
 	radxa-s0-ext-antenna.dtbo \
 	rk3308-bs-opp-1008.dtbo \
@@ -431,9 +433,6 @@ dtb-$(CONFIG_CLK_RK3588) += \
 	rock-5b-sata.dtbo
 
 dtb-$(CONFIG_CPU_RK3588) += \
-	rk3588-can1-m0.dtbo \
-	rk3588-can1-m1.dtbo \
-	rk3588-can2-m1.dtbo \
 	radxa-cm5-io-okdo-5mp.dtbo \
 	radxa-cm5-io-radxa-display-8hd.dtbo \
 	radxa-cm5-io-radxa-camera-4k.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile.rk3588-can
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile.rk3588-can
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0
+
+dtb-$(CONFIG_CPU_RK3588) += \
+	rk3588-can1-m0.dtbo \
+	rk3588-can1-m1.dtbo \
+	rk3588-can2-m1.dtbo

--- a/debian/rules
+++ b/debian/rules
@@ -13,4 +13,4 @@ override_dh_builddeb:
 	dh_builddeb -- -Zxz
 
 override_dh_install:
-	DEB_VERSION=$(DEB_VERSION) dh_install
+	DEB_VERSION=$(DEB_VERSION) dh_install -X arch/arm64/boot/dts/rockchip/overlays/Makefile.rk3588-can


### PR DESCRIPTION
* closes https://github.com/radxa-pkg/radxa-overlays/issues/316