### PR TITLE
feat: open pwm1-m2 for rock-5b-plus

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-pwm1-m2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-pwm1-m2.dts
@@ -4,11 +4,12 @@
 / {
 	metadata {
 		title = "Enable PWM1-M2";
-		compatible = "radxa,rock-5a", "radxa,rock-5c", "radxa,rock-5d";
+		compatible = "radxa,rock-5a", "radxa,rock-5b-plus", "radxa,rock-5c", "radxa,rock-5d";
 		category = "misc";
 		exclusive = "GPIO1_A3";
 		description = "Enable PWM1-M2.
 On Radxa ROCK 5A this is pin 24.
+On Radxa ROCK 5B+ this is pin 29.
 On Radxa ROCK 5C this is pin 24.
 On Radxa ROCK 5D this is pin 24.
 ";


### PR DESCRIPTION
另外 PWM1-M2 这个是否有必要打开？或者关闭 Overlay, 在 mraa 上面也关闭？之前 5B 是没有开 PWM1-M2 这个 Overlay 的

https://github.com/radxa/kernel/blob/6ca933c58c3f32d8ddd47db50af7d189120fc955/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts#L943
https://github.com/radxa/kernel/blob/6ca933c58c3f32d8ddd47db50af7d189120fc955/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts#L924