### PR TITLE
overlays: disable i2c1-m0 for ROCK5B/ROCK5B+

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-i2c1-m0.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-i2c1-m0.dts
@@ -4,13 +4,11 @@
 / {
 	metadata {
 		title = "Enable I2C1-M0";
-		compatible = "radxa,rock-5a", "radxa,rock-5b", "radxa,rock-5b-plus", "radxa,rock-5c", "radxa,rock-5d", "radxa,nx5-io", "radxa,cm5-io", "radxa,cm5-rpi-cm4-io";
+		compatible = "radxa,rock-5a", "radxa,rock-5c", "radxa,rock-5d", "radxa,nx5-io", "radxa,cm5-io", "radxa,cm5-rpi-cm4-io";
 		category = "misc";
 		exclusive = "GPIO0_B5", "GPIO0_B6";
 		description = "Enable I2C1-M0.
 On Radxa ROCK 5A this is SDA pin 10 & SCL pin 8.
-On Radxa ROCK 5B this is SDA pin 10 & SCL pin 8.
-On Radxa ROCK 5B+ this is SDA pin 10 & SCL pin 8.
 On Radxa ROCK 5C this is SDA pin 10 & SCL pin 8.
 On Radxa ROCK 5D this is SDA pin 10 & SCL pin 8.
 On Radxa NX5 IO this is SDA pin 10 & SCL pin 8.


### PR DESCRIPTION
Conflicts with pmu i2c when used on ROCK5B/ROCK5B+.