### PR TITLE
feat: add rockchip-uart-tx-dma

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -564,7 +564,8 @@ dtb-$(CONFIG_CPU_RK3588) += \
 	rock-5t-radxa-display-10fhd.dtbo \
 	rock-5t-radxa-display-10hd.dtbo
 
-dtb-$(CONFIG_ARCH_ROCKCHIP) += rockchip-watchdog.dtbo
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rockchip-watchdog.dtbo \
+	rockchip-uart-dma.dtbo
 
 dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
 	README.overlays

--- a/arch/arm64/boot/dts/rockchip/overlays/rockchip-uart-dma.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rockchip-uart-dma.dts
@@ -1,0 +1,53 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable DMA transfer mode for all UARTs";
+		compatible = "rockchip,rk3566", "rockchip,rk3568", "rockchip,rk3588";
+		category = "misc";
+		description = "Enable DMA transfer mode for all UARTs.
+DMA mode can help alleviating the CPU load when the data rate is high.
+It is not necessary to enable it at low data rate, as DMA requires additional resources to set up.";
+	};
+};
+
+&uart0 {
+	dma-names = "tx", "rx";
+};
+
+&uart1 {
+	dma-names = "tx", "rx";
+};
+
+&uart2 {
+	dma-names = "tx", "rx";
+};
+
+&uart3 {
+	dma-names = "tx", "rx";
+};
+
+&uart4 {
+	dma-names = "tx", "rx";
+};
+
+&uart5 {
+	dma-names = "tx", "rx";
+};
+
+&uart6 {
+	dma-names = "tx", "rx";
+};
+
+&uart7 {
+	dma-names = "tx", "rx";
+};
+
+&uart8 {
+	dma-names = "tx", "rx";
+};
+
+&uart9 {
+	dma-names = "tx", "rx";
+};


### PR DESCRIPTION
* closes https://github.com/radxa-pkg/radxa-overlays/issues/366

RK3399 没有定义 dmas 属性
RK33*8 默认开启dma
![image](https://github.com/user-attachments/assets/e8baffb8-8da9-4bc9-9abe-6b4239f4940a)
内核串口驱动默认配置，会导致rx dma触发cpu中断，所以不开