### PR TITLE
Radxa zero 使用 微雪spi 3.5

### DIFF
--- a/arch/arm64/boot/dts/amlogic/overlays/Makefile
+++ b/arch/arm64/boot/dts/amlogic/overlays/Makefile
@@ -43,6 +43,7 @@ dtb-$(CONFIG_ARCH_MESON) += \
 	radxa-zero-enable-vddio_c.dtbo \
 	radxa-zero-led-8-off.dtbo \
 	radxa-zero-led-10-off.dtbo \
+	radxa-zero-spi-b-waveshare35b.dtbo \
 	radxa-zero-uart-ao-b-89.dtbo \
 	radxa-zero2-enable-vddio_c.dtbo \
 	radxa-zero2-radxa-25w-poe.dtbo

--- a/arch/arm64/boot/dts/amlogic/overlays/radxa-zero-spi-b-waveshare35b.dts
+++ b/arch/arm64/boot/dts/amlogic/overlays/radxa-zero-spi-b-waveshare35b.dts
@@ -1,0 +1,55 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	metadata {
+		title = "Enable Waveshare 3.5inch RPi LCD (B) on SPI-B";
+		compatible = "radxa,zero";
+		category = "misc";
+		exclusive = "spicc1", "GPIOH_4", "GPIOH_5", "GPIOH_6", "GPIOH_7", "GPIOAO_3", "GPIOX_8", "GPIOX_9", "GPIOAO_2";
+		description = "Enable Waveshare 3.5inch RPi LCD (B) on SPI-B.";
+	};
+};
+
+&spicc1 {
+	pinctrl-0 = <&spicc1_pins>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio GPIOH_6 GPIO_ACTIVE_LOW  &gpio GPIOX_9 GPIO_ACTIVE_LOW>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+	ili9486: ili9486@0 {
+		compatible = "ilitek,ili9486";
+		reg = <0>;
+		spi-max-frequency = <120000000>;
+		txbuflen = <32768>;
+		rotate = <90>;
+		bgr = <0>;
+		fps = <50>;
+		buswidth = <8>;
+		regwidth = <16>;
+		reset-gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_LOW>;
+		dc-gpios = <&gpio GPIOX_8 GPIO_ACTIVE_HIGH>;
+		debug = <0>; 
+	};
+
+	ads7846: ads7846@1 {
+		compatible = "ti,ads7846";
+		status = "okay";
+		reg = <1>;
+		id = <1>;
+		spi-max-frequency = <2000000>;
+		ti,x-plate-ohms = /bits/ 16 <60>;
+		ti,pressure-max = /bits/ 16 <255>;
+		ti,swap-xy = <0>;
+		ti,invert-y = <1>;
+		interrupts = <2 IRQ_TYPE_EDGE_FALLING>;
+		interrupt-parent = <&gpio_intc>;
+		pendown-gpio = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
+		vcc-supply = <&ao_5v>;
+	};
+};


### PR DESCRIPTION
微雪mhs3.5屏幕

使用官方radxa-zero_debian_bullseye_cli_b23.img 镜像

内核需要添加ads7846触屏驱动
B-spi

显示屏 ：ili9486
LCD_RS （PIN18:DC）			    DC引脚        （PIN18：GPIOX_8）
RST    （PIN22：RESET）			 RESET引脚    （PIN7：GPIOAO_3）
LCD_SI （PIN19：MOSI）   		 MOSI引脚     （PIN19：GPIOH_4）
LCD_SCK（PIN23：SCLK）			 SCLK引脚     （PIN23：GPIOH_7）
LCD_CS （PING24：SS）			 SS引脚		   （PIN24：GPIOH_6）

触屏：ads7846：xpt2046
TP_IRQ  （PIN11：GPIOAO_2）           PIN11
TP_SI   （PIN19：GPIOH_4）            PIN19
TP_SO   （PIN21：GPIOH_5）            PIN21
TP_SCK  （PIN23：GPIOH_7）            PIN23
TP_CS   （PIN26：GPIOX_9）          	PIN12
