### PR TITLE
Add support for TPM SLB9670 module on RK3399 platform

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -86,6 +86,7 @@ dtb-$(CONFIG_CLK_RK3399) += \
 	rk3399-radxa-25w-poe.dtbo \
 	rk3399-rga-400.dtbo \
 	rk3399-spi-gpio-enc28j60.dtbo \
+	rk3399-spi1-cs-gpio-slb9670.dtbo \
 	rk3399-spi1-enc28j60.dtbo \
 	rk3399-spi1-jedec-nor.dtbo \
 	rk3399-spi1-mcp2515-8mhz.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-cs-gpio-slb9670.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-cs-gpio-slb9670.dts
@@ -1,0 +1,41 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/pinctrl/rockchip.h>
+
+/ {
+    metadata {
+        title = "Enable Infineon SLB9670 Trusted Platform Module (TPM) on SPI1";
+        category = "misc";
+        compatible = "rockchip,rk3399";
+        exclusive = "GPIO1_B0", "GPIO1_A7", "GPIO1_B1", "GPIO4_D5", "spi1";
+        description = "Enable Infineon SLB9670 Trusted Platform Module (TPM) on SPI1.
+Uses Pin 22 (GPIO4_D5) for CS.";
+    };
+};
+
+&spi1 {
+    status = "okay";
+    #address-cells = <1>;
+    #size-cells = <0>;
+    num-cs = <1>;
+    cs-gpios = <&gpio4 RK_PD5 RK_FUNC_GPIO>;
+    pinctrl-0 = <&spi1_clk &spi1_tx &spi1_rx>;
+
+    slb9670: slb9670@0 {
+        status = "okay";
+        compatible = "infineon,slb9670";
+        reg = <0>;
+        spi-max-frequency = <1000000>;
+    };
+};
+
+&pinctrl {
+    pinctrl-names = "default";
+    pinctrl-0 = <&disable_spi1_hw_cs0>;
+    gpio1-b2 {
+        disable_spi1_hw_cs0: disable-spi1-hw-cs0 {
+            rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
+        };
+    };
+};


### PR DESCRIPTION
This update introduces support for the Infineon SLB9670 Trusted Platform Module (TPM), which provides secure key storage and hardware random number generation (HWRNG). The implementation enables the TPM on the `spi1` bus with `CS1` using a GPIO pin for RK3399-based systems, potentially extensible to other boards.

### Key Changes

- Added the `rk3399-spi1-add-cs1.dts` overlay to support multi-CS configuration on SPI1 (**CS0 is used by the SPI-flash on some boards**)

- Introduced the `tpm-slb9670.dts` overlay to configure and activate the SLB9670 TPM using the new available CS1.

### Testing

The TPM functionality on SPI has been verified on a RockPi 4C using a GeeekPi TPM9670 Module ([EP-0149](https://wiki.52pi.com/index.php/EP-0149)) from [52pi.com](52pi.com), initially designed for the Raspberry Pi header.

**Note:** The Raspberry Pi header differs from RockPi one on **PIN 26**, which corresponds to `ADC_IN0` with no CS functionality. Therefore, redirection or bridging to **PIN 22** is required for proper operation.

I hope you find this contribution helpful.

Feel free to provide feedback or suggest further improvements.