### PR TITLE
overlays: rock-4d: increase the drive strength of i2c4 on rpi v1_3

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rock-4d-rpi-camera-v1_3.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-4d-rpi-camera-v1_3.dts
@@ -188,6 +188,14 @@
 	status = "okay";
 };
 
+&i2c4m3_xfer {
+	rockchip,pins =
+		/* i2c4_scl_m3 */
+		<3 RK_PC0 11 &pcfg_pull_up_drv_level_3>,
+		/* i2c4_sda_m3 */
+		<3 RK_PB7 11 &pcfg_pull_up_drv_level_3>;
+};
+
 &pinctrl {
 	camera {
 		cam_pwdn_gpio: cam-pwdn-gpio {


### PR DESCRIPTION
While testing the RPi v1_3 camera, the device on the I2C4 bus could not be detected. After increasing the drive strength of the I2C4 GPIO pins, the camera device was successfully recognized.