### PR TITLE
feat: Added st7789 pi-1.14-lcd

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -352,6 +352,7 @@ dtb-$(CONFIG_CPU_RK3568) += \
 	radxa-zero3-walnutpi154-lcd.dtbo \
 	radxa-zero3-tc358743.dtbo \
 	radxa-zero3-tc358743-audio.dtbo \
+	radxa-zero3-mini-pi-1.14-lcd-hat.dtbo \
 	rock-3a-radxa-display-8hd.dtbo \
 	rock-3a-radxa-display-10hd.dtbo \
 	rock-3b-radxa-8inch-display.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-zero3-mini-pi-1.14-lcd-hat.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-zero3-mini-pi-1.14-lcd-hat.dts
@@ -1,0 +1,84 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+    metadata {
+        title = "Enable Mini PiTFT 1.14 inch HAT";
+        compatible = "radxa,zero3";
+        category = "misc";
+        exclusive = "GPIO0_D1", "GPIO3_C1", "GPIO3_B0", "GPIO3_B1", "GPIO3_B2", "spi3";
+        description = "Enable Mini PiTFT 1.14 inch HAT.
+
+A custom kernel module is needed:
+github.com/radxa-pkg/radxa-overlays/pull/424";
+    };
+};
+
+&spi3 {
+    status = "okay";
+    pinctrl-names = "default", "high_speed";
+    pinctrl-0 = <&spi3m1_cs0 &spi3m1_pins>;
+    pinctrl-1 = <&spi3m1_cs0 &spi3m1_pins_hs>;
+
+    #address-cells = <1>;
+    #size-cells = <0>;
+
+    st7789v@0 {
+        compatible = "sitronix,st7789v";
+        reg = <0>;
+        spi-max-frequency = <10000000>;
+
+        rotate = <270>;
+        fps = <60>;
+
+        buswidth = <8>;
+        regwidth = <8>;
+
+        width = <135>;   // Full panel width
+        height = <240>;  // Full panel height
+
+        // Add these lines to set the offset
+        x-offset = <40>;  // Adjust this value as needed
+        y-offset = <53>;  // Adjust this value as needed
+
+        cs-gpio = <&gpio0 RK_PD1 GPIO_ACTIVE_HIGH>;
+        dc-gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
+        backlight-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_HIGH>;
+        debug = <0>;
+    };
+};
+
+&{/} {
+    buttons_joystick {
+        compatible = "gpio-keys";
+        pinctrl-names = "default";
+        pinctrl-0 = <&buttons_joystick_pins>;
+
+        key1 {
+            label = "KEY1";
+            linux,code = <KEY_UP>;
+            gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>; // GPIO3_B1
+        };
+
+        key2 {
+            label = "KEY2";
+            linux,code = <KEY_DOWN>;
+            gpios = <&gpio3 RK_PB2 GPIO_ACTIVE_LOW>; // GPIO3_B2
+        };
+    };
+};
+
+&pinctrl {
+    buttons_joystick {
+        buttons_joystick_pins: buttons-joystick-pins {
+            rockchip,pins =
+                <3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>,
+                <3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
+        };
+    };
+};


### PR DESCRIPTION
This ads an overlay for the 1.14" pi hat like this one: https://www.aliexpress.com/item/1005001685753066.html

Works under Radxa ZERO 3 Debian Build 6 and Armbian distro

To use it under Armbian:
```
apt-get git build-dep --no-install-recommends -y .
git clone https://github.com/radxa-pkg/radxa-overlays.git
cd radxa-overlays
make all deb
make build-dtbo -j$(nproc) KERNELRELEASE=$(uname -r) CONFIG_CPU_RK3568=rockchip
mkdir -p /boot/overlay/
cp arch/arm64/boot/dts/rockchip/overlays/radxa-zero3-mini-pi-1.14-lcd-hat.dtbo /boot/overlay/
fdtoverlay -v -i /boot/dtb/rockchip/rk3566-radxa-zero3.dtb -o /boot/dtb/rockchip/rk3566-radxa-zero3-patched.dtb /boot/overlay/radxa-zero3-mini-pi-1.14-lcd-hat.dtbo
```

Edit your /boot/armbianEnv.txt 
```
...
overlay_prefix=rk35xx
fdtfile=rockchip/rk3566-radxa-zero3-patched.dtb
...
```

Reboot


For the 135x240 to work with the correct offset the driver needs to be patched as well to support offsets:
```
apt install -y linux-source build-dep
tar -xf /usr/src/linux-source-*.tar.xz
cd linux-source-*/drivers/staging/fbtft/
git apply fb_st7789v.c.patch # patch with changes as file below
make -C /lib/modules/$(uname -r)/build M=$(pwd) fb_st7789v.ko
mv /usr/lib/modules/$(uname -r)/kernel/drivers/staging/fbtft/fb_st7789v.ko /usr/lib/modules/$(uname -r)/kernel/drivers/staging/fbtft/fb_st7789v.ko-old
cp fb_st7789v.ko /usr/lib/modules/$(uname -r)/kernel/drivers/staging/fbtft/.
reboot
```

fb_st7789v.c.patch
```
--- fb_st7789v-orig.c	2025-07-05 15:07:25.608286257 +0200
+++ fb_st7789v.c	2025-07-05 15:07:25.608286257 +0200
@@ -13,7 +13,7 @@
 #include <linux/interrupt.h>
 #include <linux/completion.h>
 #include <linux/module.h>
-
+#include <linux/moduleparam.h>
 #include <video/mipi_display.h>
 
 #include "fbtft.h"
@@ -30,6 +30,13 @@
 
 #define HSD20_IPS 1
 
+static int x_offset = 0;
+static int y_offset = 0;
+module_param(x_offset, int, 0444);
+MODULE_PARM_DESC(x_offset, "X offset of the display");
+module_param(y_offset, int, 0444);
+MODULE_PARM_DESC(y_offset, "Y offset of the display");
+
 /**
  * enum st7789v_command - ST7789V display controller commands
  *
@@ -142,6 +149,13 @@
  */
 static int init_display(struct fbtft_par *par)
 {
+	struct device *dev = par->info->device;
+
+	if (dev->of_node) {
+		of_property_read_u32(dev->of_node, "x-offset", &x_offset);
+		of_property_read_u32(dev->of_node, "y-offset", &y_offset);
+	}
+
 	int rc;
 
 	par->fbtftops.reset(par);
@@ -294,6 +308,33 @@
 }
 
 /**
+ * set_addr_win() - set the address window with optional offsets
+ *
+ * @par: FBTFT parameter object
+ * @xs: x start
+ * @ys: y start
+ * @xe: x end
+ * @ye: y end
+ */
+static void set_addr_win(struct fbtft_par *par, int xs, int ys, int xe, int ye)
+{
+	xs += x_offset;
+	xe += x_offset;
+	ys += y_offset;
+	ye += y_offset;
+
+	write_reg(par, MIPI_DCS_SET_COLUMN_ADDRESS,
+		  (xs >> 8) & 0xFF, xs & 0xFF,
+		  (xe >> 8) & 0xFF, xe & 0xFF);
+
+	write_reg(par, MIPI_DCS_SET_PAGE_ADDRESS,
+		  (ys >> 8) & 0xFF, ys & 0xFF,
+		  (ye >> 8) & 0xFF, ye & 0xFF);
+
+	write_reg(par, MIPI_DCS_WRITE_MEMORY_START);
+}
+
+/**
  * set_gamma() - set gamma curves
  *
  * @par: FBTFT parameter object
@@ -379,6 +420,7 @@
 		.set_var = set_var,
 		.set_gamma = set_gamma,
 		.blank = blank,
+		.set_addr_win = set_addr_win,
 	},
 };
 
@@ -389,6 +431,6 @@
 MODULE_ALIAS("spi:st7789v");
 MODULE_ALIAS("platform:st7789v");
 
-MODULE_DESCRIPTION("FB driver for the ST7789V LCD Controller");
+MODULE_DESCRIPTION("FB driver for the ST7789V LCD Controller with offset");
 MODULE_AUTHOR("Dennis Menschel");
 MODULE_LICENSE("GPL");
\ No newline at end of file
```
