### PR TITLE
feat: add mali-enable for rk3399

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -74,6 +74,7 @@ dtb-$(CONFIG_CLK_RK3399) += \
 	rk3399-i2c6.dtbo \
 	rk3399-i2c7-ds3231.dtbo \
 	rk3399-i2c7.dtbo \
+	rk3399-mali-enable.dtbo \
 	rk3399-opp-1800.dtbo \
 	rk3399-opp-2000.dtbo \
 	rk3399-opp-2200.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-mali-enable.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-mali-enable.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    metadata {
+	title = "Enable Arm Mali GPU driver";
+	compatible = "rockchip,rk3399";
+	category = "misc";
+	exclusive = "gpu", "gpu_mali";
+	description = "Enable Arm Mali GPU driver.
+This will disable opensource Panfrost driver";
+    };
+};
+
+&gpu {
+    status = "disabled";
+};
+
+&gpu_mali {
+    status = "okay";
+    mali-supply = <&vdd_gpu>;
+};


### PR DESCRIPTION
```
feat: add mali-enable for rk3399

By default, rk3399 uses the open-source Panfrost GPU driver[0]. This
change adds an overlay for enabling the proprietary Mali GPU driver.

[0]:
https://github.com/radxa/kernel/commit/eaf7a29a197d4e97a1e4482d0027ef46648e3880

Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>
```