### PR TITLE
feat: remove otg host mode support for radxa-cm4-io

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3576-dwc3-host.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3576-dwc3-host.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Set OTG port 0 to Host mode";
-		compatible = "radxa,cm4-io", "radxa,rock-4d";
+		compatible = "radxa,rock-4d";
 		category = "misc";
 		exclusive = "usb_drd0_dwc3-dr_mode";
 		description = "Set OTG port 0 to Host mode.


### PR DESCRIPTION
The OTG port on the Radxa CM4-IO can automatically switch between host and device modes. Disable this feature to resolve the issue where devices cannot be recognized after switching to host mode.
