### PR TITLE
fix: change buswidth and regwidth to 8

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-zero3-walnutpi154-lcd.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-zero3-walnutpi154-lcd.dts
@@ -27,8 +27,8 @@
 		spi-max-frequency = <60000000>;
 		rotate = <0>;
 		fps = <30>;
-		buswidth = <4>;
-		regwidth = <4>;
+		buswidth = <8>;
+		regwidth = <8>;
 		width = <240>;
 		height = <240>;
 		cs-gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-zero3-waveshare13-lcd-hat.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-zero3-waveshare13-lcd-hat.dts
@@ -27,8 +27,8 @@
 		spi-max-frequency = <10000000>;
 		rotate = <270>;
 		fps = <60>;
-		buswidth = <4>;
-		regwidth = <4>;
+		buswidth = <8>;
+		regwidth = <8>;
 		width = <240>;
 		height = <240>;
 		cs-gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
In the Debian 12 b1 img release, due to a kernel upgrade, the ST7789V driver has restricted the buswidth to 8 starting from kernel 6.1. It is no longer permitted to be 4 like the kernel 5.10.

Fixes radxa-build/radxa-zero3#38