### PR TITLE
fix: rk3399: change some deprecated overlays metadata

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-dwc3-0-otg.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-dwc3-0-otg.dts
@@ -3,11 +3,12 @@
 
 / {
 	metadata {
-		title = "Set OTG port to be controlled by hardware switch";
+		title = "Set OTG port to be controlled by hardware switch (Deprecated)";
 		compatible = "radxa,rock-pi-4a", "radxa,rock-pi-4b", "radxa,rock-pi-4c", "radxa,rock-pi-4a-plus", "radxa,rock-pi-4b-plus", "radxa,rock-4se";
 		category = "misc";
 		exclusive = "usbdrd_dwc3_0-dr_mode";
-		description = "Set OTG port to OTG mode.";
+		description = "Set OTG port to OTG mode.
+Deprecated as the latest system is already in default OTG mode.";
 	};
 };
 

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-pcie0-gen2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-pcie0-gen2.dts
@@ -3,11 +3,12 @@
 
 / {
 	metadata {
-		title = "Enable PCI Express Gen 2 negotiation";
+		title = "Enable PCI Express Gen 2 negotiation (Deprecated)";
 		compatible = "radxa,rock-pi-4a", "radxa,rock-pi-4b", "radxa,rock-pi-4c", "radxa,rock-pi-4a-plus", "radxa,rock-pi-4b-plus", "radxa,rock-4se";
 		category = "misc";
 		exclusive = "pcie0_max-link-speed";
-		description = "Enable PCI Express Gen 2 negotiation.";
+		description = "Enable PCI Express Gen 2 negotiation. 
+Deprecated as the latest system has enabled it by default";
 	};
 };
 


### PR DESCRIPTION
Link:
https://vamrs.feishu.cn/sheets/I7u5sedHZhLAV9tzSllcr793nbh?sheet=12cztX&rangeId=12cztX_kE4T2tYcLm&rangeVer=1 https://vamrs.feishu.cn/sheets/I7u5sedHZhLAV9tzSllcr793nbh?sheet=12cztX&rangeId=12cztX_4zb6PPpXCe&rangeVer=1