### PR TITLE
fix: delete q6a i2c12

### DIFF
--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c12.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c12.dtso
@@ -9,7 +9,7 @@
 / {
     metadata {
         title = "Enable I2C12";
-        compatible = "radxa,dragon-q6a";
+        compatible = "unknown";
         category = "misc";
         exclusive = "spi12", "uart12", "i2c12", "gpio48", "gpio49";
         description = "Enable I2C12.


### PR DESCRIPTION
使用这个 overlay 需要改硬件