### PR TITLE
fix: rk3399-spi1-waveshare35: remove ads7846

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-waveshare35.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-waveshare35.dts
@@ -3,20 +3,17 @@
 
 / {
 	metadata {
-		title = "Enable Waveshare 3.5inch RPi LCD (C) on SPI1";
+		title = "Enable Waveshare 3.5inch RPi LCD (C) on SPI1 (No Touch Support)";
 		compatible = "rockchip,rk3399";
 		category = "misc";
 		exclusive = "GPIO1_B0", "GPIO1_A7", "GPIO1_B1", "GPIO1_B2", "GPIO4_D2", "GPIO4_D4", "GPIO4_D5" ;
-		description = "Enable Waveshare 3.5inch RPi LCD (C) on SPI1.";
+		description = "Enable Waveshare 3.5inch RPi LCD (C) on SPI1 (No Touch Support).
+Due to hardware conflict, touch is not available when using with ROCK 4.";
 	};
 };
 
 &DISPLAY_SPI {
-	num-cs = <2>;
-	cs-gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH
-			&gpio4 RK_PD2 GPIO_ACTIVE_HIGH>;
-	pinctrl-names = "default", "high_speed";
-	pinctrl-0 = <&spi1_clk &spi1_rx &spi1_tx>;
+	pinctrl-0 = <&spi1_clk &spi1_cs0 &spi1_rx &spi1_tx>;
 };
 
 &ili9486 {
@@ -25,7 +22,5 @@
 };
 
 &ads7846 {
-	interrupts = <RK_PC2 IRQ_TYPE_EDGE_FALLING>;
-	interrupt-parent = <&gpio4>;
-	pendown-gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_HIGH>;
+	status = "disabled";
 };

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-waveshare35b.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-waveshare35b.dts
@@ -9,12 +9,6 @@ Due to hardware conflict, touch is not available when using with ROCK 4.";
 	};
 };
 
-&DISPLAY_SPI {
-	/delete-property/ num-cs;
-	/delete-property/ cs-gpios;
-	pinctrl-0 = <&spi1_clk &spi1_cs0 &spi1_rx &spi1_tx>;
-};
-
 &ili9486 {
 	init = <0x10000b0 0x0
 			0x1000011
@@ -30,8 +24,4 @@ Due to hardware conflict, touch is not available when using with ROCK 4.";
 			0x1000011
 			0x20000ff
 			0x1000029>;
-};
-
-&ads7846 {
-	status = "disabled";
 };


### PR DESCRIPTION
Remove all waveshare35 touch support because hardware conflicts are not actually supported.

The PIN_26 of the rock-4 series is ADC_IN0 and cannot be configured as a GPIO, while the TP_CS of the waveshare35 is pin 26.

Link: https://vamrs.feishu.cn/sheets/LdYzsRcWxh8eQgtcwuZcGtbPnW6?sheet=VJz6QP&rangeId=VJz6QP_01tBO3LFws&rangeVer=1