### PR TITLE
feat: add Waveshare IMX415 8MP camera support for ROCK 5B+

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -637,6 +637,8 @@ dtb-$(CONFIG_CPU_RK3588) += \
 	rock-5b-plus-cam1-rpi-camera-v1p3.dtbo \
 	rock-5b-plus-cam0-rpi-camera-v2.dtbo \
 	rock-5b-plus-cam1-rpi-camera-v2.dtbo \
+	rock-5b-plus-cam0-waveshare-imx415-8mp-camera.dtbo \
+	rock-5b-plus-cam1-waveshare-imx415-8mp-camera.dtbo \
 	rock-5b-plus-hdmi0-8k.dtbo \
 	rock-5b-plus-hdmi1-8k.dtbo \
 	rock-5b-plus-radxa-display-8hd.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5b-plus-cam0-waveshare-imx415-8mp-camera.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5b-plus-cam0-waveshare-imx415-8mp-camera.dts
@@ -1,0 +1,186 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+/ {
+	metadata {
+		title ="Enable Waveshare IMX415 8MP Camera on CAM0";
+		compatible = "radxa,rock-5b-plus";
+		category = "camera";
+		exclusive = "csi2_dphy0";
+		description = "Enable Waveshare IMX415 8MP Camera on CAM0.";
+	};
+};
+
+&{/} {
+	camera_pwdn_gpio: camera-pwdn-gpio {
+		compatible = "regulator-fixed";
+		regulator-name = "camera_pwdn_gpio";
+		regulator-always-on;
+		regulator-boot-on;
+		enable-active-high;
+		gpio = <&gpio1 RK_PB0 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&cam_pwdn_gpio>;
+	};
+
+	clk_cam_37m: external-camera-clock-37m {
+		compatible = "fixed-clock";
+		clock-frequency = <37000000>;
+		clock-output-names = "clk_cam_37m";
+		#clock-cells = <0>;
+	};
+};
+
+&i2c3 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	imx415: imx415@37 {
+		status = "okay";
+		compatible = "sony,imx415";
+		reg = <0x37>;
+
+		clocks = <&clk_cam_37m>;
+		clock-names = "xvclk";
+
+		rockchip,camera-module-index = <0>;
+		rockchip,camera-module-facing = "front";
+		rockchip,camera-module-name = "RADXA-CAMERA-4K";
+		rockchip,camera-module-lens-name = "DEFAULT";
+		port {
+			imx415_out0: endpoint {
+				remote-endpoint = <&mipidphy0_in_ucam0>;
+				data-lanes = <1 2 3 4>;
+			};
+		};
+	};
+};
+
+&csi2_dphy0_hw {
+	status = "okay";
+};
+
+&csi2_dphy0 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipidphy0_in_ucam0: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&imx415_out0>;
+				data-lanes = <1 2 3 4>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			csidphy0_out: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&mipi2_csi2_input>;
+			};
+		};
+	};
+};
+
+&mipi2_csi2 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi2_csi2_input: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&csidphy0_out>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi2_csi2_output: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&cif_mipi2_in0>;
+			};
+		};
+	};
+};
+
+&rkcif {
+	status = "okay";
+};
+
+&rkcif_mipi_lvds2 {
+	status = "okay";
+
+	port {
+		cif_mipi2_in0: endpoint {
+			remote-endpoint = <&mipi2_csi2_output>;
+		};
+	};
+};
+
+&rkcif_mipi_lvds2_sditf {
+	status = "okay";
+
+	port {
+		mipi_lvds2_sditf: endpoint {
+			remote-endpoint = <&isp0_vir0>;
+		};
+	};
+};
+
+&rkcif_mmu {
+	status = "okay";
+};
+
+&isp0_mmu {
+	status = "okay";
+};
+
+&rkisp0 {
+	status = "okay";
+};
+
+&rkisp0_vir0 {
+	status = "okay";
+
+	port {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		isp0_vir0: endpoint@0 {
+			reg = <0>;
+			remote-endpoint = <&mipi_lvds2_sditf>;
+		};
+	};
+};
+
+&pinctrl {
+	camera {
+		cam_pwdn_gpio: cam-pwdn-gpio {
+			rockchip,pins = <1 RK_PB0 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5b-plus-cam1-waveshare-imx415-8mp-camera.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5b-plus-cam1-waveshare-imx415-8mp-camera.dts
@@ -1,0 +1,188 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+/ {
+	metadata {
+		title ="Enable Waveshare IMX415 8MP Camera on CAM1";
+		compatible = "radxa,rock-5b-plus";
+		category = "camera";
+		exclusive = "csi2_dphy1";
+		description = "Enable Waveshare IMX415 8MP Camera on CAM1.";
+	};
+};
+
+&{/} {
+	camera_pwdn_gpio: camera-pwdn-gpio {
+		compatible = "regulator-fixed";
+		regulator-name = "camera_pwdn_gpio";
+		regulator-always-on;
+		regulator-boot-on;
+		enable-active-high;
+		gpio = <&gpio2 RK_PA6 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&cam_pwdn_gpio>;
+	};
+
+	clk_cam_37m_1: external-camera-clock-37m-1 {
+		compatible = "fixed-clock";
+		clock-frequency = <37000000>;
+		clock-output-names = "clk_cam_37m_1";
+		#clock-cells = <0>;
+	};
+};
+
+&i2c4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c4m1_xfer>;
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	imx415: imx415@37 {
+		status = "okay";
+		compatible = "sony,imx415";
+		reg = <0x37>;
+
+		clocks = <&clk_cam_37m_1>;
+		clock-names = "xvclk";
+
+		rockchip,camera-module-index = <1>;
+		rockchip,camera-module-facing = "back";
+		rockchip,camera-module-name = "RADXA-CAMERA-4K";
+		rockchip,camera-module-lens-name = "DEFAULT";
+		port {
+			imx415_out4: endpoint {
+				remote-endpoint = <&mipidphy4_in_ucam0>;
+				data-lanes = <1 2 3 4>;
+			};
+		};
+	};
+};
+
+&csi2_dphy1_hw {
+	status = "okay";
+};
+
+&csi2_dphy3 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipidphy4_in_ucam0: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&imx415_out4>;
+				data-lanes = <1 2 3 4>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			csidphy4_out: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&mipi4_csi2_input>;
+			};
+		};
+	};
+};
+
+&mipi4_csi2 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi4_csi2_input: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&csidphy4_out>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi4_csi2_output: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&cif_mipi4_in0>;
+			};
+		};
+	};
+};
+
+&rkcif {
+	status = "okay";
+};
+
+&rkcif_mipi_lvds4 {
+	status = "okay";
+
+	port {
+		cif_mipi4_in0: endpoint {
+			remote-endpoint = <&mipi4_csi2_output>;
+		};
+	};
+};
+
+&rkcif_mipi_lvds4_sditf {
+	status = "okay";
+
+	port {
+		mipi_lvds4_sditf: endpoint {
+			remote-endpoint = <&isp1_vir1>;
+		};
+	};
+};
+
+&rkcif_mmu {
+	status = "okay";
+};
+
+&isp1_mmu {
+	status = "okay";
+};
+
+&rkisp1 {
+	status = "okay";
+};
+
+&rkisp1_vir1 {
+	status = "okay";
+
+	port {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		isp1_vir1: endpoint@0 {
+			reg = <0>;
+			remote-endpoint = <&mipi_lvds4_sditf>;
+		};
+	};
+};
+
+&pinctrl {
+	camera {
+		cam_pwdn_gpio: cam-pwdn-gpio {
+			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+};


### PR DESCRIPTION
Add two new device tree overlays for ROCK 5B+:
- cam0: rock-5b-plus-cam0-waveshare-imx415-8mp-camera.dts
- cam1: rock-5b-plus-cam1-waveshare-imx415-8mp-camera.dts

Note:
Using the Waveshare IMX415 8MP camera requires the 'Radxa Camera FPC Cable 22P to 31P L150' for proper connection