### PR TITLE
fix: set compatible to "unknown" for meson-g12-usb*dtso

### DIFF
--- a/arch/arm64/boot/dts/amlogic/overlays/meson-g12-usb-host.dtso
+++ b/arch/arm64/boot/dts/amlogic/overlays/meson-g12-usb-host.dtso
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Set OTG port to Host mode";
-		compatible = "radxa,zero", "radxa,zero2";
+		compatible = "unknown";
 		category = "misc";
 		exclusive = "usb";
 		description = "Set OTG port to Host mode.

--- a/arch/arm64/boot/dts/amlogic/overlays/meson-g12-usb-peripheral.dtso
+++ b/arch/arm64/boot/dts/amlogic/overlays/meson-g12-usb-peripheral.dtso
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Set OTG port to Peripheral mode";
-		compatible = "radxa,zero", "radxa,zero2";
+		compatible = "unknown";
 		category = "misc";
 		exclusive = "usb";
 		description = "Set OTG port to Peripheral mode.


### PR DESCRIPTION
The meson-g12 series SOC USB controller does not support role switching

Link: https://github.com/torvalds/linux/blob/master/Documentation/ devicetree/bindings/usb/amlogic%2Cmeson-g12a-usb-ctrl.yaml#L15-L16