### PR TITLE
fix: set compatible to "unknown" for meson-g12-uart-ao-a

### DIFF
--- a/arch/arm64/boot/dts/amlogic/overlays/meson-g12-uart-ao-a.dtso
+++ b/arch/arm64/boot/dts/amlogic/overlays/meson-g12-uart-ao-a.dtso
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Enable UART_AO-A on GPIOAO_0 and GPIOAO_1";
-		compatible = "radxa,zero", "radxa,zero2";
+		compatible = "unknown";
 		category = "misc";
 		exclusive = "uart_AO", "GPIOAO_0", "GPIOAO_1";
 		description = "Enable UART_AO-A on GPIOAO_0 and GPIOAO_1.";


### PR DESCRIPTION
It's debug serial, so hide it.

Close #495