### PR TITLE
qcom: Update KVM overlay for q6a

### DIFF
--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-kvm.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-kvm.dtso
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
  * Copyright (c) 2025 Radxa Computer (Shenzhen) Co., Ltd.
+ *
+ * This device tree overlay is supposed to be applied by UEFI firmware
+ * when Hypervisor Override is set to enabled.
  */
+
+#include <dt-bindings/firmware/qcom,scm.h>
 
 /dts-v1/;
 /plugin/;
@@ -13,10 +18,11 @@
 		category = "misc";
 		exclusive = "gpu_zap_shader";
 		description = "Enable KVM virtualization support.
-This will break ADSP (audio), CDSP (NPU), and Venus (video codec)";
+This overlay has the same effect as the Hypervisor Override option in UEFI BIOS setup.";
 	};
 };
 
+/* Required when Hypervisor Override is set to auto */
 &{/chosen} {
 	radxa,enable-kvm = <1>;
 };
@@ -24,4 +30,40 @@ This will break ADSP (audio), CDSP (NPU), and Venus (video codec)";
 /* We can't and don't need to use zap shader in EL2 as linux can zap the gpu on it's own. */
 &gpu_zap_shader {
 	status = "disabled";
+};
+
+&soc {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	pcie@1c08000 {
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		/* Allow using upper PCIe space */
+		ranges = <0x01000000 0x0 0x00000000 0x0 0x40200000 0x0 0x100000>,
+			<0x02000000 0x0 0x40300000 0x0 0x40300000 0x0 0x1fd00000>,
+			<0x03000000 0x4 0x00000000 0x4 0x00000000 0x3 0x00000000>;
+	};
+};
+
+&remoteproc_adsp {
+	qcom,broken-reset;
+};
+
+&remoteproc_cdsp {
+	qcom,broken-reset;
+};
+
+&scm {
+	qcom,shm-bridge-vmid = <QCOM_SCM_VMID_SELF_OWNER>;
+};
+
+&venus {
+	iommus = <&apps_smmu 0x2180 0x20>,
+		 <&apps_smmu 0x2184 0x20>;
+
+	video-firmware {
+		iommus = <&apps_smmu 0x21a2 0x0>;
+	};
 };


### PR DESCRIPTION
ADSP (audio), CDSP (NPU), and Venus (video codec) are available in EL2 with the latest UEFI firmware (260120) and Linux 6.18.

Update the DT overlay to reflect this and enable the features.