### PR TITLE
chore: set I2C clock frequency to 100 kHz

### DIFF
--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c0.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c0.dtso
@@ -25,7 +25,7 @@ On Radxa Dragon Q6A, this is pin 15(scl), 13(sda).";
 	qcom,enable-gsi-dma;
 	status = "okay";
 
-	clock-frequency = <1000000>;
+	clock-frequency = <100000>;
 };
 
 &uart0 {

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c14.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c14.dtso
@@ -25,7 +25,7 @@ On Radxa Dragon Q6A, this is pin 22(scl), 33(sda).";
 	qcom,enable-gsi-dma;
 	status = "okay";
 
-	clock-frequency = <1000000>;
+	clock-frequency = <100000>;
 };
 
 &uart14 {

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c2.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c2.dtso
@@ -25,7 +25,7 @@ On Radxa Dragon Q6A, this is pin 28(scl), 27(sda).";
 	qcom,enable-gsi-dma;
 	status = "okay";
 
-	clock-frequency = <1000000>;
+	clock-frequency = <100000>;
 };
 
 &uart2 {

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c6.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c6.dtso
@@ -25,7 +25,7 @@ On Radxa Dragon Q6A, this is pin 5(scl), 3(sda).";
 	qcom,enable-gsi-dma;
 	status = "okay";
 
-	clock-frequency = <1000000>;
+	clock-frequency = <100000>;
 };
 
 &uart6 {


### PR DESCRIPTION
Change the I2C bus clock frequency from 1 MHz to 100 kHz (standard mode)