### PR TITLE
chore: disable dragon q6a uart12

### DIFF
--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart12.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart12.dtso
@@ -9,7 +9,7 @@
 / {
     metadata {
         title = "Enable UART12";
-        compatible = "radxa,dragon-q6a";
+        compatible = "unknown";
         category = "misc";
         exclusive = "spi12", "uart12", "i2c12";
         description = "Enable UART12. 


### PR DESCRIPTION
uart12 无法正常工作先禁用

https://applink.feishu.cn/client/message/link/open?token=Ami%2ByZSflQABaaqLusyAC7o%3D