### PR TITLE
fix: add missing gpio exclusives for qcs6490 q6a overlays

### DIFF
--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c0.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c0.dtso
@@ -11,7 +11,7 @@
 		title = "Enable I2C0";
 		compatible = "radxa,dragon-q6a";
 		category = "misc";
-		exclusive = "uart0","i2c0","spi0";
+		exclusive = "uart0","i2c0","spi0","gpio0","gpio1";
 		description = "Enable I2C0. 
 On Radxa Dragon Q6A, this is pin 15(scl), 13(sda).";
 	};

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c14.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c14.dtso
@@ -11,7 +11,7 @@
 		title = "Enable I2C14";
 		compatible = "radxa,dragon-q6a";
 		category = "misc";
-		exclusive = "uart14","i2c14","spi14";
+		exclusive = "uart14","i2c14","spi14","gpio56","gpio57";
 		description = "Enable I2C14. 
 On Radxa Dragon Q6A, this is pin 22(scl), 33(sda).";
 	};

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c2.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c2.dtso
@@ -11,7 +11,7 @@
 		title = "Enable I2C2";
 		compatible = "radxa,dragon-q6a";
 		category = "misc";
-		exclusive = "uart2","i2c2","spi2";
+		exclusive = "uart2","i2c2","spi2","gpio8","gpio9";
 		description = "Enable I2C2. 
 On Radxa Dragon Q6A, this is pin 28(scl), 27(sda).";
 	};

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c6-ssd1306.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c6-ssd1306.dtso
@@ -11,7 +11,7 @@
 		title = "Enable SSD1306 OLED Display on I2C6";
 		compatible = "radxa,dragon-q6a";
 		category = "display";
-		exclusive = "uart6", "i2c6", "spi6";
+		exclusive = "uart6", "i2c6", "spi6", "gpio24", "gpio25";
 		description = "Enable SSD1306 OLED Display on I2C6.
 
 The display resolution is fixed at 128x64.

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c6.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-i2c6.dtso
@@ -11,7 +11,7 @@
 		title = "Enable I2C6";
 		compatible = "radxa,dragon-q6a";
 		category = "misc";
-		exclusive = "uart6","i2c6","spi6";
+		exclusive = "uart6","i2c6","spi6","gpio24","gpio25";
 		description = "Enable I2C6. 
 On Radxa Dragon Q6A, this is pin 5(scl), 3(sda).";
 	};

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-spi12-cs0-mcp2515-8mhz.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-spi12-cs0-mcp2515-8mhz.dtso
@@ -14,7 +14,7 @@
 		title = "Enable MCP2515 with 8MHz external clock on SPI12 over CS0";
 		compatible = "radxa,dragon-q6a";
 		category = "misc";
-		exclusive = "spi12", "uart12", "i2c12", "gpio48", "gpio49", "gpio50", "gpio51", "GPIO_57";
+		exclusive = "spi12", "uart12", "i2c12", "gpio48", "gpio49", "gpio50", "gpio51", "gpio57";
 		description = "Enable MCP2515 with 8MHz external clock on SPI12 over CS0.
 
 Provide support for Microchip MCP2515 SPI CAN controller.

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart12-flowctl.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart12-flowctl.dtso
@@ -11,7 +11,7 @@
         title = "Enable UART12 with Flow Control";
         compatible = "radxa,dragon-q6a";
         category = "misc";
-        exclusive = "spi12", "uart12", "i2c12";
+        exclusive = "spi12", "uart12", "i2c12", "gpio48", "gpio49", "gpio50", "gpio51";
         description = "Enable UART12 with Flow Control. 
 On Radxa Dragon Q6A, this is pin 19(rts), 21(cts), 23(tx), 24(rx).";
     };

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart12.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart12.dtso
@@ -11,7 +11,7 @@
         title = "Enable UART12";
         compatible = "unknown";
         category = "misc";
-        exclusive = "spi12", "uart12", "i2c12";
+        exclusive = "spi12", "uart12", "i2c12", "gpio50", "gpio51";
         description = "Enable UART12. 
 On Radxa Dragon Q6A, this is pin 23(tx), 24(rx).";
     };

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart6-flowctl.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart6-flowctl.dtso
@@ -11,7 +11,7 @@
         title = "Enable UART6 with Flow Control";
         compatible = "radxa,dragon-q6a";
         category = "misc";
-        exclusive = "uart6","i2c6","spi6";
+        exclusive = "uart6","i2c6","spi6","gpio24","gpio25","gpio26","gpio27";
         description = "Enable UART6 with Flow Control. 
 On Radxa Dragon Q6A, this is pin  3(cts), 5(rts),16(tx), 18(rx).";
     };

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart6.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-uart6.dtso
@@ -11,7 +11,7 @@
         title = "Enable UART6";
         compatible = "radxa,dragon-q6a";
         category = "misc";
-        exclusive = "uart6","i2c6","spi6";
+        exclusive = "uart6","i2c6","spi6","gpio26","gpio27";
         description = "Enable UART6. 
 On Radxa Dragon Q6A, this is pin 16(tx), 18(rx).";
     };


### PR DESCRIPTION
## Summary
- add missing GPIO exclusive entries for qcs6490 Dragon Q6A I2C and UART overlays based on the Q6A GPIO function table
- normalize the SPI12 MCP2515 overlay exclusive metadata to use gpio57 consistently

## Testing
- make deb