### PR TITLE
fix cm3i panel and camera issues

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-8inch-display.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-8inch-display.dts
@@ -25,7 +25,19 @@
 		regulator-name = "vcc_lcd_mipi";
 		gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-boot-on;
+		regulator-always-on;
+		regulator-state-mem {
+			regulator-off-in-suspend;
+		};
+	};
+
+	vcc_lcd_dsi0_v1p4_board: vcc-lcd-dsi0-v1p4-board {
+		status = "okay";
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_lcd_mipi_v1p4_board";
+		gpio = <&gpio3 RK_PB2 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
 		regulator-state-mem {
 			regulator-off-in-suspend;
 		};
@@ -37,7 +49,7 @@
 		regulator-name = "vcc_tp";
 		gpio = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-boot-on;
+		regulator-always-on;
 		regulator-state-mem {
 			regulator-off-in-suspend;
 		};
@@ -47,40 +59,8 @@
 		status = "okay";
 		compatible = "pwm-backlight";
 		pwms = <&pwm6 0 25000 PWM_POLARITY_INVERTED>;
-		brightness-levels = <
-			0  20  20  21  21  22  22  23
-			23  24  24  25  25  26  26  27
-			27  28  28  29  29  30  30  31
-			31  32  32  33  33  34  34  35
-			35  36  36  37  37  38  38  39
-			40  41  42  43  44  45  46  47
-			48  49  50  51  52  53  54  55
-			56  57  58  59  60  61  62  63
-			64  65  66  67  68  69  70  71
-			72  73  74  75  76  77  78  79
-			80  81  82  83  84  85  86  87
-			88  89  90  91  92  93  94  95
-			96  97  98  99 100 101 102 103
-			104 105 106 107 108 109 110 111
-			112 113 114 115 116 117 118 119
-			120 121 122 123 124 125 126 127
-			128 129 130 131 132 133 134 135
-			136 137 138 139 140 141 142 143
-			144 145 146 147 148 149 150 151
-			152 153 154 155 156 157 158 159
-			160 161 162 163 164 165 166 167
-			168 169 170 171 172 173 174 175
-			176 177 178 179 180 181 182 183
-			184 185 186 187 188 189 190 191
-			192 193 194 195 196 197 198 199
-			200 201 202 203 204 205 206 207
-			208 209 210 211 212 213 214 215
-			216 217 218 219 220 221 222 223
-			224 225 226 227 228 229 230 231
-			232 233 234 235 236 237 238 239
-			240 241 242 243 244 245 246 247
-			248 249 250 251 252 253 254 255
-		>;
+		brightness-levels = <0 255>;
+		num-interpolated-steps = <255>;
 		default-brightness-level = <200>;
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-display-10fhd.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-display-10fhd.dts
@@ -25,8 +25,19 @@
 		regulator-name = "vcc_lcd_mipi";
 		gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-boot-on;
-				regulator-always-on;
+		regulator-always-on;
+		regulator-state-mem {
+			regulator-off-in-suspend;
+		};
+	};
+
+	vcc_lcd_dsi0_v1p4_board: vcc-lcd-dsi0-v1p4-board {
+		status = "okay";
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_lcd_mipi_v1p4_board";
+		gpio = <&gpio3 RK_PB2 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
 		regulator-state-mem {
 			regulator-off-in-suspend;
 		};
@@ -38,7 +49,7 @@
 		regulator-name = "vcc_tp";
 		gpio = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-boot-on;
+		regulator-always-on;
 		regulator-state-mem {
 			regulator-off-in-suspend;
 		};
@@ -48,40 +59,8 @@
 		status = "okay";
 		compatible = "pwm-backlight";
 		pwms = <&pwm6 0 25000 PWM_POLARITY_INVERTED>;
-		brightness-levels = <
-			0  20  20  21  21  22  22  23
-			23  24  24  25  25  26  26  27
-			27  28  28  29  29  30  30  31
-			31  32  32  33  33  34  34  35
-			35  36  36  37  37  38  38  39
-			40  41  42  43  44  45  46  47
-			48  49  50  51  52  53  54  55
-			56  57  58  59  60  61  62  63
-			64  65  66  67  68  69  70  71
-			72  73  74  75  76  77  78  79
-			80  81  82  83  84  85  86  87
-			88  89  90  91  92  93  94  95
-			96  97  98  99 100 101 102 103
-			104 105 106 107 108 109 110 111
-			112 113 114 115 116 117 118 119
-			120 121 122 123 124 125 126 127
-			128 129 130 131 132 133 134 135
-			136 137 138 139 140 141 142 143
-			144 145 146 147 148 149 150 151
-			152 153 154 155 156 157 158 159
-			160 161 162 163 164 165 166 167
-			168 169 170 171 172 173 174 175
-			176 177 178 179 180 181 182 183
-			184 185 186 187 188 189 190 191
-			192 193 194 195 196 197 198 199
-			200 201 202 203 204 205 206 207
-			208 209 210 211 212 213 214 215
-			216 217 218 219 220 221 222 223
-			224 225 226 227 228 229 230 231
-			232 233 234 235 236 237 238 239
-			240 241 242 243 244 245 246 247
-			248 249 250 251 252 253 254 255
-		>;
+		brightness-levels = <0 255>;
+		num-interpolated-steps = <255>;
 		default-brightness-level = <200>;
 	};
 };
@@ -101,12 +80,12 @@
 		reg = <0>;
 		backlight = <&backlight_dsi0>;
 
-				power-supply = <&vcc_lcd_dsi0>;
+		power-supply = <&vcc_lcd_dsi0>;
 		reset-gpios = <&gpio3 RK_PC0 GPIO_ACTIVE_LOW>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&dsi0_lcd_rst_gpio>;
 
-				prepare-delay-ms = <120>;
+		prepare-delay-ms = <120>;
 		reset-delay-ms = <120>;
 		init-delay-ms = <120>;
 		enable-delay-ms = <100>;

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-display-10hd.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-display-10hd.dts
@@ -25,8 +25,19 @@
 		regulator-name = "vcc_lcd_mipi";
 		gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-boot-on;
-				regulator-always-on;
+		regulator-always-on;
+		regulator-state-mem {
+			regulator-off-in-suspend;
+		};
+	};
+
+	vcc_lcd_dsi0_v1p4_board: vcc-lcd-dsi0-v1p4-board {
+		status = "okay";
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_lcd_mipi_v1p4_board";
+		gpio = <&gpio3 RK_PB2 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
 		regulator-state-mem {
 			regulator-off-in-suspend;
 		};
@@ -38,7 +49,6 @@
 		regulator-name = "vcc_tp";
 		gpio = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-boot-on;
 		regulator-always-on;
 		regulator-state-mem {
 			regulator-off-in-suspend;
@@ -49,40 +59,8 @@
 		status = "okay";
 		compatible = "pwm-backlight";
 		pwms = <&pwm6 0 25000 PWM_POLARITY_INVERTED>;
-		brightness-levels = <
-			0  20  20  21  21  22  22  23
-			23  24  24  25  25  26  26  27
-			27  28  28  29  29  30  30  31
-			31  32  32  33  33  34  34  35
-			35  36  36  37  37  38  38  39
-			40  41  42  43  44  45  46  47
-			48  49  50  51  52  53  54  55
-			56  57  58  59  60  61  62  63
-			64  65  66  67  68  69  70  71
-			72  73  74  75  76  77  78  79
-			80  81  82  83  84  85  86  87
-			88  89  90  91  92  93  94  95
-			96  97  98  99 100 101 102 103
-			104 105 106 107 108 109 110 111
-			112 113 114 115 116 117 118 119
-			120 121 122 123 124 125 126 127
-			128 129 130 131 132 133 134 135
-			136 137 138 139 140 141 142 143
-			144 145 146 147 148 149 150 151
-			152 153 154 155 156 157 158 159
-			160 161 162 163 164 165 166 167
-			168 169 170 171 172 173 174 175
-			176 177 178 179 180 181 182 183
-			184 185 186 187 188 189 190 191
-			192 193 194 195 196 197 198 199
-			200 201 202 203 204 205 206 207
-			208 209 210 211 212 213 214 215
-			216 217 218 219 220 221 222 223
-			224 225 226 227 228 229 230 231
-			232 233 234 235 236 237 238 239
-			240 241 242 243 244 245 246 247
-			248 249 250 251 252 253 254 255
-		>;
+		brightness-levels = <0 255>;
+		num-interpolated-steps = <255>;
 		default-brightness-level = <200>;
 	};
 };
@@ -103,7 +81,7 @@
 		reg = <0>;
 		backlight = <&backlight_dsi0>;
 
-				vdd-supply = <&vcc_lcd_dsi0>;
+		vdd-supply = <&vcc_lcd_dsi0>;
 		vccio-supply = <&vcc_3v3>;
 		reset-gpios = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
 		pinctrl-names = "default";

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-rpi-camera-v1p3-cam1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-rpi-camera-v1p3-cam1.dts
@@ -23,15 +23,6 @@
 		#clock-cells = <0>;
 	};
 
-	ov5647_1_pwdn_gpio: ov5647-1-pwdn-gpio {
-		status = "okay";
-		compatible = "regulator-fixed";
-		regulator-name = "ov5647_1_pwdn_gpio";
-		regulator-always-on;
-		regulator-boot-on;
-		enable-active-high;
-		gpio = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
-	};
 };
 
 &i2c0 {
@@ -48,6 +39,7 @@
 		reg = <0x36>;
 		clocks = <&ext_cam_ov5647_clk_1>;
 		clock-names = "xvclk";
+		pwdn-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
 		rockchip,camera-module-index = <0>;
 		rockchip,camera-module-facing = "front";
 		rockchip,camera-module-name = "rpi-camera-v1p3";

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-rpi-camera-v1p3-cam2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-rpi-camera-v1p3-cam2.dts
@@ -22,16 +22,6 @@
 		clock-output-names = "ext_cam_ov5647_clk_2";
 		#clock-cells = <0>;
 	};
-
-	ov5647_2_pwdn_gpio: ov5647-2-pwdn-gpio {
-		status = "okay";
-		compatible = "regulator-fixed";
-		regulator-name = "ov5647_2_pwdn_gpio";
-		regulator-always-on;
-		regulator-boot-on;
-		enable-active-high;
-		gpio = <&gpio4 RK_PC5 GPIO_ACTIVE_LOW>;
-	};
 };
 
 &i2c5 {
@@ -48,6 +38,7 @@
 		clocks = <&ext_cam_ov5647_clk_2>;
 		clock-names = "xvclk";
 		rockchip,camera-module-index = <1>;
+		pwdn-gpios = <&gpio4 RK_PC5 GPIO_ACTIVE_LOW>;
 		rockchip,camera-module-facing = "back";
 		rockchip,camera-module-name = "rpi-camera-v1p3";
 		rockchip,camera-module-lens-name = "default";


### PR DESCRIPTION
On the v1.41 board, MIPI_BL_EN_1 is changed to gpio3_b2.
Using regulator configuration for ov5647 causes probe failure.