### PR TITLE
fix: rk3568: CM3J RPI CM4 IO uses TX pin 26 RX pin 36

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3568-uart5-m1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3568-uart5-m1.dts
@@ -16,7 +16,7 @@ On Radxa CM3S IO this is TX pin 35 and RX pin 40.
 On Radxa E25 hardware V1.3 this is TX pin 2 and RX pin 3.
 On Radxa E25 hardware V1.4 this is TX pin 8 and RX pin 10.
 On Radxa ZERO 3 this is TX pin 32 and RX pin 33.
-On Radxa CM3J RPI CM4 IO this is TX pin 12 and RX pin 35.";
+On Radxa CM3J RPI CM4 IO this is TX pin 26 and RX pin 36.";
 	};
 };
 


### PR DESCRIPTION
Pin 26 is GPIO7[0]. GPIO7 connects to GPIO3_C2 on CM3J[1]. The function 4 of GPIO3_C2 on RK3568J is uart5_txm1[2].
Pin 36 is GPIO16[0]. GPI16 connects to GPIO3_C3 on CM3J[1]. The function 4 of GPIO3_C3 on RK3568J is uart5_rxm1[3].

[0]: https://pip-assets.raspberrypi.com/categories/756-raspberry-pi-compute-module-4-io-board/documents/RP-008172-DS-1-cm4io-datasheet.pdf?disposition=inline
[1]: https://dl.radxa.com/cm3j/docs/hw/radxa_cm3j_schematic_v1.2_20250115.pdf
[2]: https://github.com/radxa/kernel/blob/91a06a0c49f9d7dc304409c55c984c154ca15407/arch/arm64/boot/dts/rockchip/rk3568-pinctrl.dtsi#L2635-L2636
[3]: https://github.com/radxa/kernel/blob/91a06a0c49f9d7dc304409c55c984c154ca15407/arch/arm64/boot/dts/rockchip/rk3568-pinctrl.dtsi#L2633-L2634