### PR TITLE
feat: add display and B-key USB overlays for Radxa VMARC Q9075 IO

### DIFF
--- a/arch/arm64/boot/dts/qcom/overlays/Makefile
+++ b/arch/arm64/boot/dts/qcom/overlays/Makefile
@@ -42,6 +42,7 @@ dtb-$(CONFIG_ARCH_QCOM) += qcs6490-radxa-cm-q64-rpi-cm5-io-cam0-imx219.dtbo \
 	qcs6490-radxa-dragon-q6a-uart14.dtbo \
 	qcs6490-radxa-dragon-q6a-usb-peripheral.dtbo \
 	qcs9075-enable-dp.dtbo \
+	qcs9075-enable-edp.dtbo \
 	qcs9075-i2c16.dtbo \
 	qcs9075-i2c18.dtbo \
 	qcs9075-radxa-vmarc-q9075-io-cam1-imx577.dtbo \

--- a/arch/arm64/boot/dts/qcom/overlays/Makefile
+++ b/arch/arm64/boot/dts/qcom/overlays/Makefile
@@ -41,6 +41,7 @@ dtb-$(CONFIG_ARCH_QCOM) += qcs6490-radxa-cm-q64-rpi-cm5-io-cam0-imx219.dtbo \
 	qcs6490-radxa-dragon-q6a-uart14-flowctl.dtbo \
 	qcs6490-radxa-dragon-q6a-uart14.dtbo \
 	qcs6490-radxa-dragon-q6a-usb-peripheral.dtbo \
+	qcs9075-enable-dp.dtbo \
 	qcs9075-i2c16.dtbo \
 	qcs9075-i2c18.dtbo \
 	qcs9075-radxa-vmarc-q9075-io-cam1-imx577.dtbo \

--- a/arch/arm64/boot/dts/qcom/overlays/Makefile
+++ b/arch/arm64/boot/dts/qcom/overlays/Makefile
@@ -47,6 +47,7 @@ dtb-$(CONFIG_ARCH_QCOM) += qcs6490-radxa-cm-q64-rpi-cm5-io-cam0-imx219.dtbo \
 	qcs9075-i2c18.dtbo \
 	qcs9075-radxa-vmarc-q9075-io-cam1-imx577.dtbo \
 	qcs9075-radxa-vmarc-q9075-io-cam2-ov9281.dtbo \
+	qcs9075-radxa-vmarc-q9075-io-enable-b-key.dtbo \
 	qcs9075-radxa-vmarc-q9075-io-radxa-display-10fhd.dtbo \
 	qcs9075-radxa-vmarc-q9075-io-usb-peripheral.dtbo \
 	qcs9075-spi16-cs0-enc28j60.dtbo \

--- a/arch/arm64/boot/dts/qcom/overlays/Makefile
+++ b/arch/arm64/boot/dts/qcom/overlays/Makefile
@@ -45,6 +45,7 @@ dtb-$(CONFIG_ARCH_QCOM) += qcs6490-radxa-cm-q64-rpi-cm5-io-cam0-imx219.dtbo \
 	qcs9075-i2c18.dtbo \
 	qcs9075-radxa-vmarc-q9075-io-cam1-imx577.dtbo \
 	qcs9075-radxa-vmarc-q9075-io-cam2-ov9281.dtbo \
+	qcs9075-radxa-vmarc-q9075-io-radxa-display-10fhd.dtbo \
 	qcs9075-radxa-vmarc-q9075-io-usb-peripheral.dtbo \
 	qcs9075-spi16-cs0-enc28j60.dtbo \
 	qcs9075-spi16-cs0-mcp2515.dtbo \

--- a/arch/arm64/boot/dts/qcom/overlays/qcs9075-enable-dp.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs9075-enable-dp.dtso
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2026 Radxa Computer (Shenzhen) Co., Ltd.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Switch display from HDMI to DisplayPort";
+		compatible = "radxa,vmarc-q9075-io";
+		category = "display";
+		exclusive = "mdss0", "mdss0_dp0", "mdss0_dsi0",
+			"mdss0_edp_phy", "mdss1", "mdss1_dp0",
+			"mdss1_dp0_out", "mdss1_edp_phy", "gpio104";
+		description = "Switch display from HDMI to DisplayPort.";
+	};
+};
+
+&mdss0 {
+	status = "disabled";
+};
+
+&mdss0_dp0 {
+	status = "disabled";
+};
+
+&mdss0_edp_phy {
+	status = "disabled";
+};
+
+&mdss1 {
+	status = "okay";
+};
+
+&mdss1_dp0 {
+	pinctrl-0 = <&dp2_hot_plug_det>;
+	pinctrl-names = "default";
+
+	status = "okay";
+};
+
+&mdss1_dp0_out {
+	data-lanes = <0 1 2 3>;
+	link-frequencies = /bits/ 64 <1620000000 2700000000 5400000000 8100000000>;
+};
+
+&mdss1_edp_phy {
+	status = "okay";
+};
+
+&tlmm {
+	dp2_hot_plug_det: dp2-hot-plug-det-state {
+		pins = "gpio104";
+		function = "edp2_hot";
+		bias-disable;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/overlays/qcs9075-enable-edp.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs9075-enable-edp.dtso
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2026 Radxa Computer (Shenzhen) Co., Ltd.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/clock/qcom,sa8775p-gcc.h>
+
+/ {
+	metadata {
+		title = "Enable eDP output";
+		compatible = "radxa,vmarc-q9075-io";
+		category = "display";
+		exclusive = "mdss0", "mdss0_dp1", "mdss0_dp1_out",
+			"mdss0_edp1_phy", "gpio66", "gpio67", "gpio84";
+		description = "Enable eDP output.";
+	};
+};
+
+&{/} {
+	vcc_edp_en_regulator: vcc-edp-en-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_edp_en";
+		gpio = <&tlmm 67 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		pinctrl-names = "default";
+		pinctrl-0 = <&vcc_edp_en>;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	vcc_edp_bl_en_regulator: vcc-edp-bl-en-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_edp_bl_en";
+		gpio = <&tlmm 66 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		pinctrl-names = "default";
+		pinctrl-0 = <&vcc_edp_bl_en>;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	edp_pwm: pwm {
+		compatible = "clk-pwm";
+		#pwm-cells = <2>;
+		clocks = <&gcc GCC_GP3_CLK>;
+		gpios = <&tlmm 84 GPIO_ACTIVE_HIGH>;
+
+		pinctrl-names = "default", "gpio";
+		pinctrl-0 = <&edp_bl_pwm_clk_state>;
+		pinctrl-1 = <&edp_bl_pwm_gpio_state>;
+	};
+
+	edp-backlight {
+		compatible = "pwm-backlight";
+		pwms = <&edp_pwm 0 25000>;
+		brightness-levels = <0 255>;
+		num-interpolated-steps = <255>;
+		default-brightness-level = <255>;
+		power-supply = <&vcc_edp_bl_en_regulator>;
+		status = "okay";
+	};
+};
+
+&mdss0 {
+	status = "okay";
+};
+
+&mdss0_dp1 {
+	status = "okay";
+};
+
+&mdss0_dp1_out {
+	data-lanes = <0 1 2 3>;
+	link-frequencies = /bits/ 64 <1620000000 2700000000 5400000000 8100000000>;
+};
+
+&mdss0_edp1_phy {
+	status = "okay";
+};
+
+&tlmm {
+	vcc_edp_en: vcc-edp-en {
+		pins = "gpio67";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	vcc_edp_bl_en: vcc-edp-bl-en {
+		pins = "gpio66";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	edp_bl_pwm_clk_state: edp-bl-pwm-clk-state {
+		pins = "gpio84";
+		function = "gcc_gp3";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	edp_bl_pwm_gpio_state: edp-bl-pwm-gpio-state {
+		pins = "gpio84";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/overlays/qcs9075-radxa-vmarc-q9075-io-enable-b-key.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs9075-radxa-vmarc-q9075-io-enable-b-key.dtso
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2026 Radxa Computer (Shenzhen) Co., Ltd.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	metadata {
+		title = "Switch USB from M.2 E-key to M.2 B-key";
+		compatible = "radxa,vmarc-q9075-io";
+		category = "misc";
+		exclusive = "switch-to-ekey-usb-regulator",
+			"pmm8654au_2_gpio11";
+		description = "Switch USB from M.2 E-key to M.2 B-key.
+Enable this if you need to use WWAN modules.";
+	};
+};
+
+&switch_to_ekey_usb_regulator {
+	status = "disabled";
+};
+
+&pmm8654au_2_gpios {
+	bkey_usb_select_hog: bkey-usb-select-hog {
+		gpio-hog;
+		gpios = <11 GPIO_ACTIVE_HIGH>;
+		output-low;
+		line-name = "bkey-usb-select";
+	};
+};

--- a/arch/arm64/boot/dts/qcom/overlays/qcs9075-radxa-vmarc-q9075-io-radxa-display-10fhd.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs9075-radxa-vmarc-q9075-io-radxa-display-10fhd.dtso
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2026 Radxa Computer (Shenzhen) Co., Ltd.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/clock/qcom,sa8775p-gcc.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	metadata {
+		title = "Enable Radxa Display 10FHD";
+		compatible = "radxa,vmarc-q9075-io";
+		category = "display";
+		exclusive = "mdss0_dsi0", "gpio68", "gpio69", "gpio42", "gpio77", "gpio76", "gpio31";
+		description = "Enable Radxa Display 10FHD.";
+	};
+};
+
+&{/} {
+	lcd_3v3_regulator: lcd-3v3-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "lcd_3v3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		startup-delay-us = <100000>;
+		gpio = <&tlmm 68 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		vin-supply = <&vcc3v3_sys_regulator>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd_3v3_enable>;
+	};
+
+	lcd_backlight_regulator: lcd-backlight-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "lcd_backlight_12v";
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+		gpio = <&tlmm 69 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd_backlight_enable>;
+	};
+
+	lcd_pwm: pwm {
+		compatible = "clk-pwm";
+		#pwm-cells = <2>;
+		clocks = <&gcc GCC_GP5_CLK>;
+		gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default", "gpio";
+		pinctrl-0 = <&lcd_backlight_pwm_clk>;
+		pinctrl-1 = <&lcd_backlight_pwm_gpio>;
+	};
+
+	backlight_dsi: backlight-dsi {
+		compatible = "pwm-backlight";
+		pwms = <&lcd_pwm 0 25000>;
+		brightness-levels = <0 255>;
+		num-interpolated-steps = <255>;
+		default-brightness-level = <250>;
+		power-supply = <&lcd_backlight_regulator>;
+	};
+};
+
+&mdss0 {
+	status = "okay";
+};
+
+&mdss0_dsi0 {
+	vdda-supply = <&vreg_l1c>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	panel: panel@0 {
+		compatible = "radxa,display-10fhd-ad003";
+		reg = <0>;
+		backlight = <&backlight_dsi>;
+		vccio-supply = <&vcc_1v8_regulator>;
+		vdd-supply = <&lcd_3v3_regulator>;
+		reset-gpios = <&tlmm 77 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd_panel_reset>;
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&mdss0_dsi0_out>;
+			};
+		};
+	};
+};
+
+&mdss0_dsi0_out {
+	remote-endpoint = <&panel_in>;
+	data-lanes = <0 1 2 3>;
+};
+
+&mdss0_dsi0_phy {
+	vdds-supply = <&vreg_l4a>;
+	status = "okay";
+};
+
+&i2c18 {
+	clock-frequency = <100000>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&qup_i2c18_default>;
+	status = "okay";
+
+	touchscreen@14 {
+		compatible = "goodix,gt9271";
+		reg = <0x14>;
+
+		interrupt-parent = <&tlmm>;
+		interrupts = <76 IRQ_TYPE_EDGE_FALLING>;
+
+		irq-gpios = <&tlmm 76 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+
+		AVDD28-supply = <&lcd_3v3_regulator>;
+		VDDIO-supply = <&lcd_3v3_regulator>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&touchscreen_interrupt>, <&touchscreen_reset>;
+	};
+};
+
+&tlmm {
+	lcd_3v3_enable: lcd-3v3-enable-state {
+		pins = "gpio68";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	lcd_backlight_enable: lcd-backlight-enable-state {
+		pins = "gpio69";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	lcd_backlight_pwm_clk: lcd-backlight-pwm-clk-state {
+		pins = "gpio42";
+		function = "gcc_gp5";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	lcd_backlight_pwm_gpio: lcd-backlight-pwm-gpio-state {
+		pins = "gpio42";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	lcd_panel_reset: lcd-panel-reset-state {
+		pins = "gpio77";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	touchscreen_interrupt: touchscreen-interrupt-state {
+		pins = "gpio76";
+		function = "gpio";
+		bias-disable;
+	};
+
+	touchscreen_reset: touchscreen-reset-state {
+		pins = "gpio31";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+};


### PR DESCRIPTION
feat: add display and B-key USB overlays for Radxa VMARC Q9075 IO