### PR TITLE
fix: restrict OTG peripheral overlay to Airbox Q900

### DIFF
--- a/arch/arm64/boot/dts/qcom/overlays/qcs9075-usb0-peripheral.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs9075-usb0-peripheral.dtso
@@ -9,7 +9,7 @@
 / {
 	metadata {
 		title = "Set OTG port to Peripheral mode";
-		compatible = "qcom,qcs9075";
+		compatible = "radxa,airbox-q900";
 		category = "misc";
 		exclusive = "usb_0";
 		description = "Set OTG port to Peripheral mode.


### PR DESCRIPTION
The qcs9075-usb0-peripheral overlay is not generic — it only works on Radxa Airbox Q900. Change the compatible string from the generic qcom,qcs9075 to radxa,airbox-q900 to prevent it from being applied on other QCS9075 boards like VMARC Q9075 IO.