### PR TITLE
fix: correct sc8280xp uart6 pin description for V1.3

### DIFF
--- a/arch/arm64/boot/dts/qcom/overlays/sc8280xp-uart6.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/sc8280xp-uart6.dtso
@@ -13,7 +13,7 @@
 		category = "misc";
 		exclusive = "spi6", "uart6", "i2c6", "gpio156", "gpio157";
 		description = "Enable UART6.
-On Radxa Dragon Q8B, this is pin 32(tx), 29(rx).";
+On Radxa Dragon Q8B, this is pin 31(tx), 29(rx).";
 	};
 };
 


### PR DESCRIPTION
Radxa Dragon Q8B V1.3 changes the UART6 TX position on the 40-pin header from pin 32 to pin 31. Update the description accordingly; the RX position remains on pin 29.