### PR TITLE
overlay: qcom: radxa-dragon-q6a: add 8hd 2lane support

### DIFF
--- a/arch/arm64/boot/dts/qcom/overlays/Makefile
+++ b/arch/arm64/boot/dts/qcom/overlays/Makefile
@@ -23,6 +23,7 @@ dtb-$(CONFIG_ARCH_QCOM) += qcs6490-radxa-cm-q64-rpi-cm5-io-cam0-imx219.dtbo \
 	qcs6490-radxa-dragon-q6a-kvm.dtbo \
 	qcs6490-radxa-dragon-q6a-poe-hat.dtbo \
 	qcs6490-radxa-dragon-q6a-radxa-display-8hd.dtbo \
+	qcs6490-radxa-dragon-q6a-radxa-display-8hd-2lane.dtbo \
 	qcs6490-radxa-dragon-q6a-radxa-display-10fhd.dtbo \
 	qcs6490-radxa-dragon-q6a-spi12-waveshare35b.dtbo \
 	qcs6490-radxa-dragon-q6a-spi12-waveshare35c.dtbo \

--- a/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-radxa-display-8hd-2lane.dtso
+++ b/arch/arm64/boot/dts/qcom/overlays/qcs6490-radxa-dragon-q6a-radxa-display-8hd-2lane.dtso
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2025 Radxa Computer (Shenzhen) Co., Ltd.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	metadata {
+		title = "Enable Radxa Display 8HD AD002 With 2 Lane";
+		compatible = "radxa,dragon-q6a";
+		category = "display";
+		exclusive = "mdss_dsi";
+		description = "Enable Radxa Display 8HD AD002 With 2 Lane.";
+	};
+};
+
+&{/} {
+	vcc_3v3_lcd: vcc-3v3-lcd-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_3v3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&tlmm 80 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		vin-supply = <&vcc_3v3>;
+	};
+
+	backlight_dsi: backlight-dsi {
+		compatible = "pwm-backlight";
+		pwms = <&pm8350c_pwm 3 50000>;
+		enable-gpios = <&pm8350c_gpios 8 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd_bl_pwm>;
+		brightness-levels = <255 0>;
+		num-interpolated-steps = <255>;
+		default-brightness-level = <250>;
+	};
+};
+
+&mdss {
+	status = "okay";
+};
+
+&mdss_dsi {
+	vdda-supply = <&vreg_l6b_1p2>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	status = "okay";
+
+	panel: panel@0 {
+		status = "okay";
+		compatible = "radxa,display-8hd-ad002-2lane";
+		reg = <0>;
+		backlight = <&backlight_dsi>;
+
+		vdd-supply = <&vcc_3v3_lcd>;
+		vccio-supply = <&vcc_1v8>;
+		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd_panel_reset>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				panel_in_dsi1: endpoint {
+					remote-endpoint = <&mdss_dsi0_out>;
+				};
+			};
+		};
+	};
+};
+
+&mdss_dsi0_out {
+	remote-endpoint = <&panel_in_dsi1>;
+	data-lanes = <0 1>;
+};
+
+&mdss_dsi_phy {
+	vdds-supply = <&vreg_l10c_0p88>;
+	status = "okay";
+};
+
+&qupv3_id_1 {
+	status = "okay";
+};
+
+&i2c13 {
+	clock-frequency = <100000>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	status = "okay";
+
+	touchscreen@14 {
+		compatible = "goodix,gt911";
+		reg = <0x14>;
+		interrupt-parent = <&tlmm>;
+		interrupts = <81 IRQ_TYPE_LEVEL_HIGH>;
+		irq-gpios = <&tlmm 81 GPIO_ACTIVE_HIGH>;
+		pinctrl-0 = <&ts_int_conn>, <&ts_rst_conn>;
+		pinctrl-names = "default";
+		reset-gpios = <&tlmm 105 GPIO_ACTIVE_HIGH>;
+		touchscreen-size-x = <800>;
+		touchscreen-size-y = <1280>;
+	};
+};
+
+&tlmm {
+	lcd_panel_reset: lcd-panel-reset {
+		pins = "gpio44";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	ts_int_conn: ts-int-conn-state {
+		pins = "gpio81";
+		function = "gpio";
+		bias-disable;
+	};
+
+	ts_rst_conn: ts-rst-conn-state {
+		pins = "gpio105";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+};
+
+&pm8350c_gpios {
+	lcd_bl_pwm: dsi-lcd-bl-pwm-state {
+		pins = "gpio8";
+		function = "func1";
+		bias-disable;
+		qcom,drive-strength = <PMIC_GPIO_STRENGTH_LOW>;
+		output-low;
+		power-source = <0>;
+	};
+};
+
+&pm8350c_pwm {
+	status = "okay";
+};


### PR DESCRIPTION
Using the 7.0 kernel with ubuntu26 on dragin q6a, the radxa 8hd 4lane cannot be used for normal display, 
and the 2lane is used instead