### PR TITLE
feat: add RK628 HDMI input overlays for ROCK 5T and ROCK 5T Industrial

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -679,6 +679,7 @@ dtb-$(CONFIG_CPU_RK3588) += \
 	rock-5t-industrial-cam1-okdo-5mp-camera.dtbo \
 	rock-5t-industrial-cam1-radxa-camera-4k.dtbo \
 	rock-5t-industrial-cam1-radxa-camera-8m-219.dtbo \
+	rock-5t-industrial-cam1-radxa-hdmi-in-4k-rk628.dtbo \
 	rock-5t-industrial-cam1-rpi-camera-v1p3.dtbo \
 	rock-5t-industrial-cam1-rpi-camera-v2.dtbo \
 	rock-5t-industrial-radxa-display-8hd.dtbo \
@@ -693,6 +694,7 @@ dtb-$(CONFIG_CPU_RK3588) += \
 	rock-5t-cam1-radxa-camera-4k.dtbo \
 	rock-5t-cam1-radxa-camera-8m-219.dtbo \
 	rock-5t-cam1-radxa-camera-13m-214.dtbo \
+	rock-5t-cam0-radxa-hdmi-in-4k-rk628.dtbo \
 	rock-5t-cam0-rpi-camera-v1p3.dtbo \
 	rock-5t-cam1-rpi-camera-v1p3.dtbo \
 	rock-5t-cam0-rpi-camera-v2.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-i2s2-2ch-m1-capture-only.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-i2s2-2ch-m1-capture-only.dts
@@ -4,12 +4,15 @@
 / {
 	metadata {
 		title = "Enable I2S2-M1 capture-only dummy sound card";
-		compatible = "radxa,rock-5b", "radxa,rock-5b-plus";
+		compatible = "radxa,rock-5b", "radxa,rock-5b-plus", "radxa,rock-5t", "radxa,rock-5t-industrial";
 		category = "misc";
 		exclusive = "GPIO3_B5", "GPIO3_B6", "GPIO3_B2", "i2s2_2ch";
 		description = "Enable I2S2-M1 capture-only dummy sound card in slave mode.
 On Radxa ROCK 5B this is pin38 for SDI0, pin35 for LRCK, pin12 for SCLK.
-On Radxa ROCK 5B+ this is pin38 for SDI0, pin35 for LRCK, pin12 for SCLK.";
+On Radxa ROCK 5B+ this is pin38 for SDI0, pin35 for LRCK, pin12 for SCLK.
+On Radxa ROCK 5T this is pin38 for SDI0, pin35 for LRCK, pin12 for SCLK.
+On Radxa ROCK 5T Industrial this is pin38 for SDI0, pin35 for LRCK, pin12 for SCLK.
+";
 	};
 };
 

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-radxa-hdmi-in-4k-rk628-cam1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-radxa-hdmi-in-4k-rk628-cam1.dtsi
@@ -1,0 +1,144 @@
+#ifndef __RK3588_RADXA_HDMI_IN_4K_RK628_CAM1_DTSI__
+#define __RK3588_RADXA_HDMI_IN_4K_RK628_CAM1_DTSI__
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/power/rk3588-power.h>
+
+#ifndef RK628_CAM1_I2C
+#error "RK628_CAM1_I2C is undefined."
+#endif
+
+/ {
+	metadata {
+		title = "Enable Radxa 4K HDMI IN to MIPI CSI-2 Adapter on CAM1";
+		category = "camera";
+		exclusive = "csi2_dphy1", "GPIO2_A6", "GPIO2_B0", "GPIO2_A7";
+		description = "Enable Radxa 4K HDMI IN to MIPI CSI-2 Adapter on CAM1.
+To capture audio, also enable the 'I2S2-M1 capture-only dummy sound card' overlay.";
+	};
+};
+
+&RK628_CAM1_I2C {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	rk628_csi_cam1: rk628-csi@50 {
+		compatible = "rockchip,rk628-csi-v4l2";
+		reg = <0x50>;
+		power-domains = <&power RK3588_PD_VI>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&rk628_cam1_pin>;
+		interrupt-parent = <&gpio2>;
+		interrupts = <RK_PA6 IRQ_TYPE_LEVEL_HIGH>;
+		reset-gpios = <&gpio2 RK_PB0 GPIO_ACTIVE_LOW>;
+		plugin-det-gpios = <&gpio2 RK_PA7 GPIO_ACTIVE_LOW>;
+		continues-clk = <1>;
+
+		rockchip,camera-module-index = <1>;
+		rockchip,camera-module-facing = "back";
+		rockchip,camera-module-name = "HDMI-MIPI2";
+		rockchip,camera-module-lens-name = "RK628-CSI";
+
+		port {
+			hdmiin_out_cam1: endpoint {
+				remote-endpoint = <&hdmi2mipi_in_cam1>;
+				data-lanes = <1 2 3 4>;
+			};
+		};
+	};
+};
+
+&csi2_dphy1_hw {
+	status = "okay";
+};
+
+&csi2_dphy3 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			hdmi2mipi_in_cam1: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&hdmiin_out_cam1>;
+				data-lanes = <1 2 3 4>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+
+			csidphy3_out_cam1: endpoint {
+				remote-endpoint = <&mipi4_csi2_input_cam1>;
+			};
+		};
+	};
+};
+
+&mipi4_csi2 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi4_csi2_input_cam1: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&csidphy3_out_cam1>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+
+			mipi4_csi2_output_cam1: endpoint {
+				remote-endpoint = <&cif_mipi4_in_cam1>;
+			};
+		};
+	};
+};
+
+&rkcif {
+	status = "okay";
+};
+
+&rkcif_mipi_lvds4 {
+	status = "okay";
+
+	port {
+		cif_mipi4_in_cam1: endpoint {
+			remote-endpoint = <&mipi4_csi2_output_cam1>;
+		};
+	};
+};
+
+&rkcif_mmu {
+	status = "okay";
+};
+
+&pinctrl {
+	hdmiin {
+		rk628_cam1_pin: rk628-cam1-pin {
+			rockchip,pins =
+				<2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>,
+				<2 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>,
+				<2 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+};
+
+#endif // __RK3588_RADXA_HDMI_IN_4K_RK628_CAM1_DTSI__

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5b-plus-cam1-radxa-hdmi-in-4k-rk628.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5b-plus-cam1-radxa-hdmi-in-4k-rk628.dts
@@ -1,141 +1,16 @@
 /dts-v1/;
 /plugin/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/interrupt-controller/irq.h>
-#include <dt-bindings/pinctrl/rockchip.h>
-#include <dt-bindings/power/rk3588-power.h>
+#define RK628_CAM1_I2C i2c4
+#include "rk3588-radxa-hdmi-in-4k-rk628-cam1.dtsi"
 
 / {
 	metadata {
-		title = "Enable Radxa 4K HDMI IN to MIPI CSI-2 Adapter on CAM1";
-		compatible = "radxa,rock-5b-plus";
-		category = "camera";
-		exclusive = "csi2_dphy1", "GPIO2_A6", "GPIO2_B0", "GPIO2_A7";
-		description = "Enable Radxa 4K HDMI IN to MIPI CSI-2 Adapter on CAM1.
-To capture audio, also enable the 'I2S2-M1 capture-only dummy sound card' overlay.";
+		compatible = "radxa,rock-5b-plus", "radxa,rock-5t";
 	};
 };
 
 &i2c4 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c4m1_xfer>;
-	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	rk628_csi_cam1: rk628-csi@50 {
-		compatible = "rockchip,rk628-csi-v4l2";
-		reg = <0x50>;
-		power-domains = <&power RK3588_PD_VI>;
-		pinctrl-names = "default";
-		pinctrl-0 = <&rk628_cam1_pin>;
-		interrupt-parent = <&gpio2>;
-		interrupts = <RK_PA6 IRQ_TYPE_LEVEL_HIGH>;
-		reset-gpios = <&gpio2 RK_PB0 GPIO_ACTIVE_LOW>;
-		plugin-det-gpios = <&gpio2 RK_PA7 GPIO_ACTIVE_LOW>;
-		continues-clk = <1>;
-
-		rockchip,camera-module-index = <1>;
-		rockchip,camera-module-facing = "back";
-		rockchip,camera-module-name = "HDMI-MIPI2";
-		rockchip,camera-module-lens-name = "RK628-CSI";
-
-		port {
-			hdmiin_out_cam1: endpoint {
-				remote-endpoint = <&hdmi2mipi_in_cam1>;
-				data-lanes = <1 2 3 4>;
-			};
-		};
-	};
-};
-
-&csi2_dphy1_hw {
-	status = "okay";
-};
-
-&csi2_dphy3 {
-	status = "okay";
-
-	ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		port@0 {
-			reg = <0>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			hdmi2mipi_in_cam1: endpoint@1 {
-				reg = <1>;
-				remote-endpoint = <&hdmiin_out_cam1>;
-				data-lanes = <1 2 3 4>;
-			};
-		};
-
-		port@1 {
-			reg = <1>;
-
-			csidphy3_out_cam1: endpoint {
-				remote-endpoint = <&mipi4_csi2_input_cam1>;
-			};
-		};
-	};
-};
-
-&mipi4_csi2 {
-	status = "okay";
-
-	ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		port@0 {
-			reg = <0>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			mipi4_csi2_input_cam1: endpoint@1 {
-				reg = <1>;
-				remote-endpoint = <&csidphy3_out_cam1>;
-			};
-		};
-
-		port@1 {
-			reg = <1>;
-
-			mipi4_csi2_output_cam1: endpoint {
-				remote-endpoint = <&cif_mipi4_in_cam1>;
-			};
-		};
-	};
-};
-
-&rkcif {
-	status = "okay";
-};
-
-&rkcif_mipi_lvds4 {
-	status = "okay";
-
-	port {
-		cif_mipi4_in_cam1: endpoint {
-			remote-endpoint = <&mipi4_csi2_output_cam1>;
-		};
-	};
-};
-
-&rkcif_mmu {
-	status = "okay";
-};
-
-&pinctrl {
-	hdmiin {
-		rk628_cam1_pin: rk628-cam1-pin {
-			rockchip,pins =
-				<2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>,
-				<2 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>,
-				<2 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
 };

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5t-cam0-radxa-hdmi-in-4k-rk628.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5t-cam0-radxa-hdmi-in-4k-rk628.dts
@@ -1,0 +1,25 @@
+#include "rock-5a-radxa-hdmi-in-4k-rk628.dts"
+
+/ {
+	metadata {
+		title = "Enable Radxa 4K HDMI IN to MIPI CSI-2 Adapter on CAM0";
+		compatible = "radxa,rock-5t", "radxa,rock-5t-industrial";
+		exclusive = "csi2_dphy0", "GPIO1_D3", "GPIO2_C5", "GPIO1_C4";
+		description = "Enable Radxa 4K HDMI IN to MIPI CSI-2 Adapter on CAM0.
+To capture audio, also enable the 'I2S2-M1 capture-only dummy sound card' overlay.";
+	};
+};
+
+&rk628_csi {
+	interrupt-parent = <&gpio1>;
+	interrupts = <RK_PD3 IRQ_TYPE_LEVEL_HIGH>;
+	reset-gpios = <&gpio2 RK_PC5 GPIO_ACTIVE_LOW>;
+	plugin-det-gpios = <&gpio1 RK_PC4 GPIO_ACTIVE_LOW>;
+};
+
+&rk628_pin {
+	rockchip,pins =
+		<1 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>,
+		<2 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>,
+		<1 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
+};

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5t-industrial-cam1-radxa-hdmi-in-4k-rk628.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5t-industrial-cam1-radxa-hdmi-in-4k-rk628.dts
@@ -1,0 +1,11 @@
+/dts-v1/;
+/plugin/;
+
+#define RK628_CAM1_I2C i2c6
+#include "rk3588-radxa-hdmi-in-4k-rk628-cam1.dtsi"
+
+/ {
+	metadata {
+		compatible = "radxa,rock-5t-industrial";
+	};
+};


### PR DESCRIPTION
对于 ROCK 5B+/ROCK 5T/ROCK 5T Industrial 的 CAM1 接口配置，5B+ 与 5T 完全一致，但 5T Industrial 与 5T 的 I2C 不同，所以提取了 rk3588-radxa-hdmi-in-4k-rk628-cam1.dtsi 做为公共部分，I2C 不同的问题，使用 RK628_CAM1_I2C 宏来为三个板型配置。