### PR TITLE
feat: add ROCK 5C AR0234 RAW8 and RAW10 overlays

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -641,7 +641,8 @@ dtb-$(CONFIG_CPU_RK3588) += \
 	rock-5a-okdo-5mp-camera.dtbo \
 	rock-5a-radxa-camera-12m-577.dtbo \
 	rock-5a-radxa-camera-4k.dtbo \
-	rock-5a-radxa-camera-2m-ar0234.dtbo \
+	rock-5a-radxa-camera-2m-ar0234-8bit.dtbo \
+	rock-5a-radxa-camera-2m-ar0234-10bit.dtbo \
 	rock-5a-radxa-camera-8m-219.dtbo \
 	rock-5a-radxa-camera-13m-214.dtbo \
 	rock-5a-radxa-hdmi-in-4k-rk628.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5a-radxa-camera-2m-ar0234-10bit.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5a-radxa-camera-2m-ar0234-10bit.dts
@@ -6,11 +6,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 2M AR0234";
+		title = "Enable Radxa Camera 2M AR0234 with RAW10 format";
 		compatible = "radxa,rock-5a", "radxa,rock-5c";
 		category = "camera";
 		exclusive = "csi2_dphy0", "GPIO1_D2";
-		description = "Enable Radxa Camera AR0234.";
+		description = "Enable Radxa Camera 2M AR0234 with RAW10 format.";
 	};
 };
 
@@ -32,7 +32,7 @@
 			ar0234_out0: endpoint {
 				remote-endpoint = <&mipidphy0_in_ucam1>;
 				data-lanes = <1 2 3 4>;
-				link-frequencies = /bits/ 64 <360000000>;
+				link-frequencies = /bits/ 64 <450000000>;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5a-radxa-camera-2m-ar0234-8bit.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5a-radxa-camera-2m-ar0234-8bit.dts
@@ -1,0 +1,156 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+/ {
+	metadata {
+		title = "Enable Radxa Camera 2M AR0234 with RAW8 format";
+		compatible = "radxa,rock-5a", "radxa,rock-5c";
+		category = "camera";
+		exclusive = "csi2_dphy0", "GPIO1_D2";
+		description = "Enable Radxa Camera 2M AR0234 with RAW8 format.";
+	};
+};
+
+&i2c3 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	camera_ar0234: camera-ar0234@10 {
+		compatible = "onnn,ar0234cs";
+		reg = <0x10>;
+		reset-gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
+		rockchip,camera-module-index = <0>;
+		rockchip,camera-module-facing = "back";
+		rockchip,camera-module-name = "default";
+		rockchip,camera-module-lens-name = "default";
+
+		port {
+			ar0234_out0: endpoint {
+				remote-endpoint = <&mipidphy0_in_ucam1>;
+				data-lanes = <1 2 3 4>;
+				link-frequencies = /bits/ 64 <360000000>;
+			};
+		};
+	};
+};
+
+&csi2_dphy0_hw {
+	status = "okay";
+};
+
+&csi2_dphy0 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipidphy0_in_ucam1: endpoint@2 {
+				reg = <2>;
+				remote-endpoint = <&ar0234_out0>;
+				data-lanes = <1 2 3 4>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			csidphy0_out: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&mipi2_csi2_input>;
+			};
+		};
+	};
+};
+
+&mipi2_csi2 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi2_csi2_input: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&csidphy0_out>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi2_csi2_output: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&cif_mipi2_in0>;
+			};
+		};
+	};
+};
+
+&rkcif {
+	status = "okay";
+};
+
+&rkcif_mipi_lvds2 {
+	status = "okay";
+
+	port {
+		cif_mipi2_in0: endpoint {
+			remote-endpoint = <&mipi2_csi2_output>;
+		};
+	};
+};
+
+&rkcif_mipi_lvds2_sditf {
+	status = "okay";
+
+	port {
+		mipi_lvds2_sditf: endpoint {
+			remote-endpoint = <&isp0_vir0>;
+		};
+	};
+};
+
+&rkcif_mmu {
+	status = "okay";
+};
+
+&isp0_mmu {
+	status = "okay";
+};
+
+&rkisp0 {
+	status = "okay";
+};
+
+&rkisp0_vir0 {
+	status = "okay";
+
+	port {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		isp0_vir0: endpoint@0 {
+			reg = <0>;
+			remote-endpoint = <&mipi_lvds2_sditf>;
+		};
+	};
+};


### PR DESCRIPTION
Replace the existing fixed-mode overlay because RAW8 and RAW10 require different link frequencies.